### PR TITLE
Inject environment variables in Compose file

### DIFF
--- a/receiver/compose.go
+++ b/receiver/compose.go
@@ -41,7 +41,7 @@ func NewCompose(composeFilePath, projectName string) *Compose {
 }
 
 func (c *Compose) Build() error {
-	cmd := exec.Command("docker-compose", "-p", c.projectName, "build")
+	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "build")
 
 	if err := runCommand(cmd); err != nil {
 		return err
@@ -51,7 +51,7 @@ func (c *Compose) Build() error {
 }
 
 func (c *Compose) GetContainerId(service string) (string, error) {
-	out, err := exec.Command("docker-compose", "-p", c.projectName, "ps", "-q", service).Output()
+	out, err := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "ps", "-q", service).Output()
 
 	if err != nil {
 		return "", err
@@ -61,7 +61,7 @@ func (c *Compose) GetContainerId(service string) (string, error) {
 }
 
 func (c *Compose) Pull() error {
-	cmd := exec.Command("docker-compose", "-p", c.projectName, "pull")
+	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "pull")
 
 	if err := runCommand(cmd); err != nil {
 		return err
@@ -71,7 +71,7 @@ func (c *Compose) Pull() error {
 }
 
 func (c *Compose) Up() error {
-	cmd := exec.Command("docker-compose", "-p", c.projectName, "up", "-d")
+	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "up", "-d")
 
 	if err := runCommand(cmd); err != nil {
 		return err

--- a/receiver/compose_file.go
+++ b/receiver/compose_file.go
@@ -32,18 +32,18 @@ func (c *ComposeFile) isVersion2() bool {
 	return c.Yaml["version"] != nil && c.Yaml["version"] == "2"
 }
 
-func (c *ComposeFile) webService() map[interface{}]interface{} {
+func (c *ComposeFile) service(serviceName string) map[interface{}]interface{} {
 	if c.isVersion2() {
-		return c.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})
+		return c.Yaml["services"].(map[interface{}]interface{})[serviceName].(map[interface{}]interface{})
 	}
 
-	return c.Yaml["web"].(map[interface{}]interface{})
+	return c.Yaml[serviceName].(map[interface{}]interface{})
 }
 
 func (c *ComposeFile) InjectEnvironmentVariables(environmentVariables map[string]string) {
 	var envString string
 
-	webService := c.webService()
+	webService := c.service("web")
 	environment := webService["environment"].([]interface{})
 
 	for key, value := range environmentVariables {

--- a/receiver/compose_file.go
+++ b/receiver/compose_file.go
@@ -8,7 +8,7 @@ import (
 
 type ComposeFile struct {
 	filePath string
-	yaml     map[interface{}]interface{}
+	Yaml     map[interface{}]interface{}
 }
 
 func NewComposeFile(composeFilePath string) (*ComposeFile, error) {
@@ -28,6 +28,28 @@ func NewComposeFile(composeFilePath string) (*ComposeFile, error) {
 	return &ComposeFile{composeFilePath, m}, nil
 }
 
+func (c *ComposeFile) webService() map[interface{}]interface{} {
+	if c.IsVersion2() {
+		return c.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})
+	}
+
+	return c.Yaml["web"].(map[interface{}]interface{})
+}
+
+func (c *ComposeFile) InjectEnvironmentVariables(environmentVariables map[string]string) {
+	var envString string
+
+	webService := c.webService()
+	environment := webService["environment"].([]interface{})
+
+	for key, value := range environmentVariables {
+		envString = key + "=" + value
+		environment = append(environment, envString)
+	}
+
+	webService["environment"] = environment
+}
+
 func (c *ComposeFile) IsVersion2() bool {
-	return c.yaml["version"] != nil && c.yaml["version"] == "2"
+	return c.Yaml["version"] != nil && c.Yaml["version"] == "2"
 }

--- a/receiver/compose_file.go
+++ b/receiver/compose_file.go
@@ -53,3 +53,17 @@ func (c *ComposeFile) InjectEnvironmentVariables(environmentVariables map[string
 func (c *ComposeFile) IsVersion2() bool {
 	return c.Yaml["version"] != nil && c.Yaml["version"] == "2"
 }
+
+func (c *ComposeFile) SaveAs(filePath string) error {
+	data, err := yaml.Marshal(c.Yaml)
+
+	if err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(filePath, data, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/receiver/compose_file.go
+++ b/receiver/compose_file.go
@@ -28,8 +28,12 @@ func NewComposeFile(composeFilePath string) (*ComposeFile, error) {
 	return &ComposeFile{composeFilePath, m}, nil
 }
 
+func (c *ComposeFile) isVersion2() bool {
+	return c.Yaml["version"] != nil && c.Yaml["version"] == "2"
+}
+
 func (c *ComposeFile) webService() map[interface{}]interface{} {
-	if c.IsVersion2() {
+	if c.isVersion2() {
 		return c.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})
 	}
 
@@ -48,10 +52,6 @@ func (c *ComposeFile) InjectEnvironmentVariables(environmentVariables map[string
 	}
 
 	webService["environment"] = environment
-}
-
-func (c *ComposeFile) IsVersion2() bool {
-	return c.Yaml["version"] != nil && c.Yaml["version"] == "2"
 }
 
 func (c *ComposeFile) SaveAs(filePath string) error {

--- a/receiver/compose_file.go
+++ b/receiver/compose_file.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+type ComposeFile struct {
+	filePath string
+	yaml     map[interface{}]interface{}
+}
+
+func NewComposeFile(composeFilePath string) (*ComposeFile, error) {
+	buf, err := ioutil.ReadFile(composeFilePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(buf, &m)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &ComposeFile{composeFilePath, m}, nil
+}
+
+func (c *ComposeFile) IsVersion2() bool {
+	return c.yaml["version"] != nil && c.yaml["version"] == "2"
+}

--- a/receiver/compose_file_test.go
+++ b/receiver/compose_file_test.go
@@ -88,18 +88,6 @@ func TestInjectEnvironmentVariables(t *testing.T) {
 	}
 }
 
-func TestIsVersion2(t *testing.T) {
-	setup()
-
-	if V1ComposeFile.IsVersion2() {
-		t.Fatalf(V1FilePath + " is actually not based on Compose File Version 2.")
-	}
-
-	if !V2ComposeFile.IsVersion2() {
-		t.Fatalf(V2FilePath + " is actually based on Compose File Version 2.")
-	}
-}
-
 func TestSaveAs(t *testing.T) {
 	setup()
 

--- a/receiver/compose_file_test.go
+++ b/receiver/compose_file_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsVersion2(t *testing.T) {
+	workingDir, _ := os.Getwd()
+
+	v1FilePath := filepath.Join(workingDir, "fixtures", "docker-compose-v1.yml")
+	v1ComposeFile, _ := NewComposeFile(v1FilePath)
+
+	if v1ComposeFile.IsVersion2() {
+		t.Fatalf(v1FilePath + " is actually not based on Compose File Version 2.")
+	}
+
+	v2FilePath := filepath.Join(workingDir, "fixtures", "docker-compose-v2.yml")
+	v2ComposeFile, _ := NewComposeFile(v2FilePath)
+
+	if !v2ComposeFile.IsVersion2() {
+		t.Fatalf(v2FilePath + " is actually based on Compose File Version 2.")
+	}
+}

--- a/receiver/compose_file_test.go
+++ b/receiver/compose_file_test.go
@@ -64,6 +64,10 @@ func TestInjectEnvironmentVariables(t *testing.T) {
 		}
 	}
 
+	if !contains(webEnvironment, "DATABASE_HOST=db") {
+		t.Fatalf("Original string DATABASE_HOST=db is dismissed. environments: %v", V1ComposeFile.Yaml["web"].(map[interface{}]interface{})["environment"].([]interface{}))
+	}
+
 	V2ComposeFile.InjectEnvironmentVariables(environmentVariables)
 	webEnvironment = V2ComposeFile.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})["environment"].([]interface{})
 
@@ -81,10 +85,16 @@ func TestInjectEnvironmentVariables(t *testing.T) {
 
 	V2ComposeFile.InjectEnvironmentVariables(environmentVariables)
 	webEnvironment = V2ComposeFile.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})["environment"].([]interface{})
-	envString = "FOO=hogefugapiyo"
 
-	if !contains(webEnvironment, envString) {
-		t.Fatalf("Failed to update existing key FOO. expected: hogefugapiyo, actual: %v", webEnvironment)
+	oldEnvString := "FOO=hoge"
+	newEnvString := "FOO=hogefugapiyo"
+
+	if contains(webEnvironment, oldEnvString) {
+		t.Fatalf("Failed to update existing key FOO. %s still exists.", oldEnvString)
+	}
+
+	if !contains(webEnvironment, newEnvString) {
+		t.Fatalf("Failed to update existing key FOO. %s does not exist.", newEnvString)
 	}
 }
 

--- a/receiver/compose_file_test.go
+++ b/receiver/compose_file_test.go
@@ -6,20 +6,28 @@ import (
 	"testing"
 )
 
-func TestIsVersion2(t *testing.T) {
+var (
+	V1FilePath, V2FilePath       string
+	V1ComposeFile, V2ComposeFile *ComposeFile
+)
+
+func setup() {
 	workingDir, _ := os.Getwd()
 
-	v1FilePath := filepath.Join(workingDir, "fixtures", "docker-compose-v1.yml")
-	v1ComposeFile, _ := NewComposeFile(v1FilePath)
+	V1FilePath = filepath.Join(workingDir, "fixtures", "docker-compose-v1.yml")
+	V2FilePath = filepath.Join(workingDir, "fixtures", "docker-compose-v2.yml")
+	V1ComposeFile, _ = NewComposeFile(V1FilePath)
+	V2ComposeFile, _ = NewComposeFile(V2FilePath)
+}
 
-	if v1ComposeFile.IsVersion2() {
-		t.Fatalf(v1FilePath + " is actually not based on Compose File Version 2.")
+func TestIsVersion2(t *testing.T) {
+	setup()
+
+	if V1ComposeFile.IsVersion2() {
+		t.Fatalf(V1FilePath + " is actually not based on Compose File Version 2.")
 	}
 
-	v2FilePath := filepath.Join(workingDir, "fixtures", "docker-compose-v2.yml")
-	v2ComposeFile, _ := NewComposeFile(v2FilePath)
-
-	if !v2ComposeFile.IsVersion2() {
-		t.Fatalf(v2FilePath + " is actually based on Compose File Version 2.")
+	if !V2ComposeFile.IsVersion2() {
+		t.Fatalf(V2FilePath + " is actually based on Compose File Version 2.")
 	}
 }

--- a/receiver/compose_file_test.go
+++ b/receiver/compose_file_test.go
@@ -23,6 +23,12 @@ func contains(slice []interface{}, item string) bool {
 	return ok
 }
 
+func fileExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+
+	return err == nil
+}
+
 func setup() {
 	workingDir, _ := os.Getwd()
 
@@ -92,4 +98,24 @@ func TestIsVersion2(t *testing.T) {
 	if !V2ComposeFile.IsVersion2() {
 		t.Fatalf(V2FilePath + " is actually based on Compose File Version 2.")
 	}
+}
+
+func TestSaveAs(t *testing.T) {
+	setup()
+
+	newFilePath := filepath.Join("/tmp", "new-docker-compose.yml")
+
+	if fileExists(newFilePath) {
+		os.Remove(newFilePath)
+	}
+
+	if err := V1ComposeFile.SaveAs(newFilePath); err != nil {
+		t.Fatalf("SaveAs() fails: %s", err.Error())
+	}
+
+	if !fileExists(newFilePath) {
+		t.Fatalf("SaveAs() does not create %s", newFilePath)
+	}
+
+	os.Remove(newFilePath)
 }

--- a/receiver/etcd.go
+++ b/receiver/etcd.go
@@ -42,6 +42,22 @@ func (c *Etcd) HasKey(key string) bool {
 	return err == nil
 }
 
+func (c *Etcd) List(key string, recursive bool) ([]string, error) {
+	result := []string{}
+
+	resp, err := c.keysAPI.Get(context.Background(), key, &client.GetOptions{Recursive: recursive})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, node := range resp.Node.Nodes {
+		result = append(result, node.Key)
+	}
+
+	return result, nil
+}
+
 func (c *Etcd) Mkdir(key string) error {
 	_, err := c.keysAPI.Set(context.Background(), key, "", &client.SetOptions{Dir: true})
 

--- a/receiver/fixtures/docker-compose-v1.yml
+++ b/receiver/fixtures/docker-compose-v1.yml
@@ -1,0 +1,13 @@
+db:
+  image: postgres:9.4
+web:
+  build: .
+  command: bin/rails s -p 8080 -b '0.0.0.0'
+  environment:
+    - DATABASE_HOST=db
+    - DATABASE_PORT=5432
+    - DATABASE_USER=postgres
+  ports:
+    - 8080
+  links:
+    - db

--- a/receiver/fixtures/docker-compose-v2.yml
+++ b/receiver/fixtures/docker-compose-v2.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  db:
+    image: postgres:9.4
+  web:
+    build: .
+    command: bin/rails s -p 8080 -b '0.0.0.0'
+    environment:
+      - DATABASE_HOST=db
+      - DATABASE_PORT=5432
+      - DATABASE_USER=postgres
+    ports:
+      - 8080
+    links:
+      - db

--- a/receiver/glide.lock
+++ b/receiver/glide.lock
@@ -1,14 +1,14 @@
-hash: c7666cdb4136cf27bdc7a3ba647383156858ffef398476397f21556d2fdae0b6
-updated: 2016-04-15T18:48:03.426504968+09:00
+hash: cd105316c837ab220a71bb9274991162f7a8766b7494f2346b7e6f6177a96880
+updated: 2016-04-18T14:52:12.08358811+09:00
 imports:
 - name: github.com/coreos/etcd
-  version: 4ee7cad116c74c1cc8ce88487a7d9284036da894
+  version: ea6a747fc1d9bb6a38e84d47020732630755cb8c
   subpackages:
   - client
   - pkg/pathutil
   - pkg/types
 - name: github.com/fsouza/go-dockerclient
-  version: 23c589186c2a92a8742da55f19aec4997dae5cbb
+  version: ff3d4ee4753705a048db1855113026395c26a79a
   subpackages:
   - external/github.com/docker/docker/opts
   - external/github.com/docker/docker/pkg/archive
@@ -35,4 +35,6 @@ imports:
   version: fb93926129b8ec0056f2f458b1f519654814edf0
   subpackages:
   - context
+- name: gopkg.in/yaml.v2
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 devImports: []

--- a/receiver/glide.yaml
+++ b/receiver/glide.yaml
@@ -4,3 +4,4 @@ import:
 - package: github.com/coreos/etcd
   subpackages:
   - client
+- package: gopkg.in/yaml.v2


### PR DESCRIPTION
from 
- https://github.com/dtan4/paus-gitreceive/issues/4
- https://github.com/dtan4/paus/issues/4
- https://github.com/dtan4/paus-frontend/pull/6
## WHY

To launch application with external services, environment variable injection is required.
## WHAT

Inject environment variables as `environment` section of `web` service in `docker-compose.yml`.

before:

``` yaml
db:
  image: postgres:9.4
web:
  build: .
  command: bin/rails s -p 8080 -b '0.0.0.0'
  environment:
    - DATABASE_HOST=db
    - DATABASE_PORT=5432
    - DATABASE_USER=postgres
  ports:
    - 8080
  links:
    - db
```

after (injected `FOO` and `BAR`) :

``` yaml
db:
  image: postgres:9.4
web:
  build: .
  command: bin/rails s -p 8080 -b '0.0.0.0'
  environment:
    - DATABASE_HOST=db
    - DATABASE_PORT=5432
    - DATABASE_USER=postgres
    - FOO=hoge
    - BAR=fuga
  ports:
    - 8080
  links:
    - db

```
