### PR TITLE
Require PAUS_BASE_DOMAIN at launch time

### DIFF
--- a/receiver/main.go
+++ b/receiver/main.go
@@ -220,7 +220,12 @@ func unpackReceivedFiles(repositoryDir, username, projectName string, stdin io.R
 }
 
 func main() {
-	baseDomain := "pausapp.com"
+	baseDomain := os.Getenv("PAUS_BASE_DOMAIN")
+
+	if baseDomain == "" {
+		fmt.Fprintln(os.Stderr, "PAUS_BASE_DOMAIN is not set")
+		os.Exit(1)
+	}
 
 	dockerHost := os.Getenv("DOCKER_HOST")
 


### PR DESCRIPTION
## WHY

We should set base domain as we like.
## WHAT

Require `PAUS_BASE_DOMAIN` at launch time.
