### PR TITLE
Load config from environment variable and file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ paus-gitreceive does:
 - Build Docker image from `Dockerfile` in the repository
 - Deploy application using [Docker Compose](https://docs.docker.com/compose/)
 - Register application metadata and [Vulcand](https://github.com/vulcand/vulcand) routing information in etcd
+
+## Environment variables
+
+| Key                  | Required | Description                                    | Default                 | Example                 |
+|----------------------|----------|------------------------------------------------|-------------------------|-------------------------|
+| `PAUS_BASE_DOMAIN`   | Required | Base domain for application URL                |                         | `pausapp.com`           |
+| `PAUS_DOCKER_HOST` |          | Endpoint of Docker daemon                       | `tcp://127.0.0.1:2375` | `tcp://127.0.0.1:2377` (Docker Swarm) |
+| `PAUS_ETCD_ENDPOINT` |          | Endpoint of etcd cluster                       | `http://127.0.0.1:2379` | `http://127.0.0.1:2379` |
+| `PAUS_REPOSITORY_DIR`    |          | Directory to store repository files | `/repos/`                   | `/repos`                  |

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ paus-gitreceive does:
 | `PAUS_BASE_DOMAIN`   | Required | Base domain for application URL                |                         | `pausapp.com`           |
 | `PAUS_DOCKER_HOST` |          | Endpoint of Docker daemon                       | `tcp://127.0.0.1:2375` | `tcp://127.0.0.1:2377` (Docker Swarm) |
 | `PAUS_ETCD_ENDPOINT` |          | Endpoint of etcd cluster                       | `http://127.0.0.1:2379` | `http://127.0.0.1:2379` |
-| `PAUS_REPOSITORY_DIR`    |          | Directory to store repository files | `/repos/`                   | `/repos`                  |
+| `PAUS_REPOSITORY_DIR`    |          | Directory to store repository files | `/repos`                   | `/repos`                  |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,27 +5,31 @@ if [ ! -d /home/git/.ssh ]; then
   chown -R git /home/git/.ssh
 fi
 
-if [ ! -d /root/paus/config ]; then
-  mkdir -p /root/paus/config
+if [ ! -d /root/paus ]; then
+  mkdir -p /root/paus
 fi
 
+touch /root/paus/config
+
 if [ -n "$PAUS_BASE_DOMAIN" ]; then
-  echo $PAUS_BASE_DOMAIN > /root/paus/config/BaseDomain
+  echo "BaseDomain=$PAUS_BASE_DOMAIN" >> /root/paus/config
 else
   echo "required key PAUS_BASE_DOMAIN missing value"
   exit 1
 fi
 
 if [ -n "$PAUS_DOCKER_HOST" ]; then
-  echo $PAUS_DOCKER_HOST > /root/paus/config/DockerHost
+  echo "DockerHost=$PAUS_DOCKER_HOST" >> /root/paus/config
 fi
 
 if [ -n "$PAUS_ETCD_ENDPOINT" ]; then
-  echo $PAUS_ETCD_ENDPOINT > /root/paus/config/EtcdEndpoint
+  echo "EtcdEndpoint=$PAUS_ETCD_ENDPOINT" >> /root/paus/config
 fi
 
 if [ -n "$PAUS_REPOSITORY_DIR" ]; then
-  echo $PAUS_REPOSITORY_DIR > /root/paus/config/RepositoryDir
+  echo "RepositoryDir=$PAUS_REPOSITORY_DIR" >> /root/paus/config
 fi
+
+cat /root/paus/config
 
 exec $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,4 @@ if [ -n "$PAUS_REPOSITORY_DIR" ]; then
   echo "RepositoryDir=$PAUS_REPOSITORY_DIR" >> /root/paus/config
 fi
 
-cat /root/paus/config
-
 exec $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,10 +5,27 @@ if [ ! -d /home/git/.ssh ]; then
   chown -R git /home/git/.ssh
 fi
 
+if [ ! -d /root/paus/config ]; then
+  mkdir -p /root/paus/config
+fi
+
 if [ -n "$PAUS_BASE_DOMAIN" ]; then
-  echo $PAUS_BASE_DOMAIN > /base-domain
+  echo $PAUS_BASE_DOMAIN > /root/paus/config/BaseDomain
 else
-  echo "example.com" > /base-domain
+  echo "required key PAUS_BASE_DOMAIN missing value"
+  exit 1
+fi
+
+if [ -n "$PAUS_DOCKER_HOST" ]; then
+  echo $PAUS_DOCKER_HOST > /root/paus/config/DockerHost
+fi
+
+if [ -n "$PAUS_ETCD_ENDPOINT" ]; then
+  echo $PAUS_ETCD_ENDPOINT > /root/paus/config/EtcdEndpoint
+fi
+
+if [ -n "$PAUS_REPOSITORY_DIR" ]; then
+  echo $PAUS_REPOSITORY_DIR > /root/paus/config/RepositoryDir
 fi
 
 exec $@

--- a/receiver/config.go
+++ b/receiver/config.go
@@ -1,18 +1,49 @@
 package main
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+
 	"github.com/kelseyhightower/envconfig"
 )
 
 const (
-	ConfigPrefix = "paus"
+	ConfigPrefix    = "paus"
+	ConfigDirectory = "/root/paus/config"
+)
+
+var (
+	ConfigNames = []string{
+		"BaseDomain",
+		"DockerHost",
+		"EtcdEndpoint",
+		"RepositoryDir",
+	}
 )
 
 type Config struct {
-	BaseDomain    string `envconfig:"base_domain"    required:"true"`
+	BaseDomain    string `envconfig:"base_domain"`
 	DockerHost    string `envconfig:"docker_host"    default:"tcp://localhost:2375"`
 	EtcdEndpoint  string `envconfig:"etcd_endpoint"  default:"http://localhost:2379"`
 	RepositoryDir string `envconfig:"repository_dir" default:"/repos"`
+}
+
+func fileExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+
+	return err == nil
+}
+
+func loadConfigFromFile(filePath string) (string, error) {
+	buf, err := ioutil.ReadFile(filePath)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(buf), nil
 }
 
 func LoadConfig() (*Config, error) {
@@ -22,6 +53,22 @@ func LoadConfig() (*Config, error) {
 
 	if err != nil {
 		return nil, err
+	}
+
+	for _, configName := range ConfigNames {
+		filePath := filepath.Join(ConfigDirectory, configName)
+
+		if !fileExists(filePath) {
+			continue
+		}
+
+		configValue, err := loadConfigFromFile(filePath)
+
+		if err != nil {
+			return nil, err
+		}
+
+		reflect.ValueOf(&config).Elem().FieldByName(configName).SetString(configValue)
 	}
 
 	return &config, nil

--- a/receiver/config.go
+++ b/receiver/config.go
@@ -30,12 +30,6 @@ type Config struct {
 	RepositoryDir string `envconfig:"repository_dir" default:"/repos"`
 }
 
-func fileExists(filePath string) bool {
-	_, err := os.Stat(filePath)
-
-	return err == nil
-}
-
 func loadConfigFromFile(filePath string) (map[string]string, error) {
 	config := map[string]string{}
 
@@ -73,7 +67,7 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
-	if !fileExists(ConfigFilePath) {
+	if _, err := os.Stat(ConfigFilePath); err != nil {
 		return &config, nil
 	}
 

--- a/receiver/config.go
+++ b/receiver/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"reflect"
 	"strings"

--- a/receiver/config.go
+++ b/receiver/config.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/kelseyhightower/envconfig"
+)
+
+const (
+	ConfigPrefix = "paus"
+)
+
+type Config struct {
+	BaseDomain    string `envconfig:"base_domain"    required:"true"`
+	DockerHost    string `envconfig:"docker_host"    default:"tcp://localhost:2375"`
+	EtcdEndpoint  string `envconfig:"etcd_endpoint"  default:"http://localhost:2379"`
+	RepositoryDir string `envconfig:"repository_dir" default:"/repos"`
+}
+
+func LoadConfig() (*Config, error) {
+	var config Config
+
+	err := envconfig.Process(ConfigPrefix, &config)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}

--- a/receiver/glide.lock
+++ b/receiver/glide.lock
@@ -1,14 +1,14 @@
-hash: cd105316c837ab220a71bb9274991162f7a8766b7494f2346b7e6f6177a96880
-updated: 2016-04-18T14:52:12.08358811+09:00
+hash: fe3d08ec5c47ee25cc4b31c95e8f3946040c7d2230b5595e2694b310907fe4d8
+updated: 2016-04-20T16:32:21.243475622+09:00
 imports:
 - name: github.com/coreos/etcd
-  version: ea6a747fc1d9bb6a38e84d47020732630755cb8c
+  version: 0c40f4a7e3e00ce19b17742289cedab27247323e
   subpackages:
   - client
   - pkg/pathutil
   - pkg/types
 - name: github.com/fsouza/go-dockerclient
-  version: ff3d4ee4753705a048db1855113026395c26a79a
+  version: 7e2450a717e8725de58dc1530218cd64117861b3
   subpackages:
   - external/github.com/docker/docker/opts
   - external/github.com/docker/docker/pkg/archive
@@ -27,6 +27,8 @@ imports:
   - external/github.com/opencontainers/runc/libcontainer/user
   - external/golang.org/x/sys/unix
   - external/golang.org/x/net/context
+- name: github.com/kelseyhightower/envconfig
+  version: cea086319492c3940683ea5e122aa5de70a33923
 - name: github.com/ugorji/go
   version: a396ed22fc049df733440d90efe17475e3929ccb
   subpackages:

--- a/receiver/glide.yaml
+++ b/receiver/glide.yaml
@@ -5,3 +5,4 @@ import:
   subpackages:
   - client
 - package: gopkg.in/yaml.v2
+- package: github.com/kelseyhightower/envconfig


### PR DESCRIPTION
## WHY

Current method to set config is not so good.
Additionally, we have to load config from file, because `receiver` is called by `git` user.
## WHAT

Use `envconfig` to load config from environment variables, and read `/root/paus/config`.
