### PR TITLE
Change repository directory owner to git

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,7 @@ fi
 
 if [ -n "$PAUS_REPOSITORY_DIR" ]; then
   echo "RepositoryDir=$PAUS_REPOSITORY_DIR" >> /root/paus/config
+  chown -R git:git $PAUS_REPOSITORY_DIR
 fi
 
 exec $@


### PR DESCRIPTION
## WHY

Repository directory is created by `root`, so user `git` cannot create subdirectory.
## WHAT

Change the owner of repository directory to `git:git`.
