### PR TITLE
Rewrite ports not to bind to fixed port

### DIFF
--- a/receiver/compose_file_test.go
+++ b/receiver/compose_file_test.go
@@ -98,6 +98,24 @@ func TestInjectEnvironmentVariables(t *testing.T) {
 	}
 }
 
+func TestRewritePortBindings(t *testing.T) {
+	setup()
+
+	V1ComposeFile.RewritePortBindings()
+	v1Ports := V1ComposeFile.Yaml["web"].(map[interface{}]interface{})["ports"].([]interface{})
+
+	if len(v1Ports) != 1 || v1Ports[0] != "8080" {
+		t.Fatalf("Failed to rewrite ports. Expect: [8080], actual: %v", v1Ports)
+	}
+
+	V2ComposeFile.RewritePortBindings()
+	v2Ports := V2ComposeFile.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})["ports"].([]interface{})
+
+	if len(v2Ports) != 1 || v2Ports[0] != "8080" {
+		t.Fatalf("Failed to rewrite ports. Expect: [8080], actual: %v", v2Ports)
+	}
+}
+
 func TestSaveAs(t *testing.T) {
 	setup()
 

--- a/receiver/fixtures/docker-compose-v2.yml
+++ b/receiver/fixtures/docker-compose-v2.yml
@@ -10,6 +10,6 @@ services:
       - DATABASE_PORT=5432
       - DATABASE_USER=postgres
     ports:
-      - 8080
+      - "80:8080"
     links:
       - db

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -260,6 +260,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	composeFile.RewritePortBindings()
 	newComposeFilePath := filepath.Join(repositoryPath, "docker-compose-"+strconv.FormatInt(time.Now().Unix(), 10)+".yml")
 
 	if err = composeFile.SaveAs(newComposeFilePath); err != nil {


### PR DESCRIPTION
## WHY

`docker-compose.yml` for Paus should not fix local port. However, removing them by hand is so bothering.
## WHAT

Remove fixed port bindings automatically.
