### PR TITLE
Inverse condition whether key exists or not

### DIFF
--- a/receiver/main.go
+++ b/receiver/main.go
@@ -90,13 +90,13 @@ func injectEnvironmentVariables(application *Application, composeFile *ComposeFi
 func registerApplicationMetadata(application *Application, etcd *Etcd) error {
 	userDirectoryKey := "/paus/users/" + application.Username
 
-	if etcd.HasKey(userDirectoryKey) {
+	if !etcd.HasKey(userDirectoryKey) {
 		_ = etcd.Mkdir(userDirectoryKey)
 	}
 
 	appDirectoryKey := userDirectoryKey + "/" + application.AppName
 
-	if etcd.HasKey(appDirectoryKey) {
+	if !etcd.HasKey(appDirectoryKey) {
 		_ = etcd.Mkdir(appDirectoryKey)
 		_ = etcd.Mkdir(appDirectoryKey + "/envs")
 		_ = etcd.Mkdir(appDirectoryKey + "/revisions")


### PR DESCRIPTION
## WHY

`/envs` and `/revisions` keys are not created at the first deploy.
## WHAT

Inverse condition of `if` sentence...
