### PR TITLE
Stop deploy if command execution fails

### DIFF
--- a/receiver/compose.go
+++ b/receiver/compose.go
@@ -30,7 +30,9 @@ func runCommand(command *exec.Cmd) error {
 		fmt.Println(scanner.Text())
 	}
 
-	command.Wait()
+	if err = command.Wait(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
## WHY

Deploy process, e.g. `docker-compose build` sometimes fails. However, paus-gitreceive continues deploy and causes no container error.

```
Installing activesupport 4.2.5
An error occurred while installing nokogiri (1.6.7.2), and Bundler cannot
continue.
Make sure that `gem install nokogiri -v '1.6.7.2'` succeeds before bundling.
=====> Application container is launched.
remote: json: cannot unmarshal array into Go value of type docker.Container
To git@paus:dtan4/rails-sample
```
## WHAT

Stop deploy immediately if external command execution fails
