### PR TITLE
Fix bugs around build-time variables

### DIFF
--- a/receiver/compose_file.go
+++ b/receiver/compose_file.go
@@ -40,7 +40,7 @@ func NewComposeFile(composeFilePath string) (*ComposeFile, error) {
 }
 
 func (c *ComposeFile) buildArgs(service map[interface{}]interface{}) []interface{} {
-	b := service["build"].(map[interface{}]interface{})["arg"]
+	b := service["build"].(map[interface{}]interface{})["args"]
 
 	if b == nil {
 		return []interface{}{}
@@ -165,7 +165,7 @@ func (c *ComposeFile) InjectBuildArgs(buildArgs map[string]string) {
 		newBuildArgs = append(newBuildArgs, buildArgString)
 	}
 
-	webService["build"].(map[interface{}]interface{})["arg"] = newBuildArgs
+	webService["build"].(map[interface{}]interface{})["args"] = newBuildArgs
 }
 
 func (c *ComposeFile) InjectEnvironmentVariables(environmentVariables map[string]string) {

--- a/receiver/compose_file_test.go
+++ b/receiver/compose_file_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	V1FilePath, V2FilePath, V2FilePathNoBuildEnv          string
-	V1ComposeFile, V2ComposeFile, V2ComposeFileNoBuildEnv *ComposeFile
+	V1FilePath, V2FilePath, V2FilePathBuildArg, V2FilePathNoBuildEnv             string
+	V1ComposeFile, V2ComposeFile, V2ComposeFileBuildArg, V2ComposeFileNoBuildEnv *ComposeFile
 )
 
 func contains(slice []interface{}, item string) bool {
@@ -34,9 +34,11 @@ func setup() {
 
 	V1FilePath = filepath.Join(workingDir, "fixtures", "docker-compose-v1.yml")
 	V2FilePath = filepath.Join(workingDir, "fixtures", "docker-compose-v2.yml")
+	V2FilePathBuildArg = filepath.Join(workingDir, "fixtures", "docker-compose-v2-buildarg.yml")
 	V2FilePathNoBuildEnv = filepath.Join(workingDir, "fixtures", "docker-compose-v2-nobuildenv.yml")
 	V1ComposeFile, _ = NewComposeFile(V1FilePath)
 	V2ComposeFile, _ = NewComposeFile(V2FilePath)
+	V2ComposeFileBuildArg, _ = NewComposeFile(V2FilePathBuildArg)
 	V2ComposeFileNoBuildEnv, _ = NewComposeFile(V2FilePathNoBuildEnv)
 }
 
@@ -60,7 +62,7 @@ func TestInjectBuildArgs(t *testing.T) {
 	V2ComposeFile.InjectBuildArgs(buildArgs)
 	webService := V2ComposeFile.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})
 
-	webBuildArgs = webService["build"].(map[interface{}]interface{})["arg"].([]interface{})
+	webBuildArgs = webService["build"].(map[interface{}]interface{})["args"].([]interface{})
 
 	for key, value := range buildArgs {
 		buildArgString = key + "=" + value
@@ -73,8 +75,8 @@ func TestInjectBuildArgs(t *testing.T) {
 	buildArgs = map[string]string{
 		"FOO": "hogefugapiyo",
 	}
-	V2ComposeFile.InjectBuildArgs(buildArgs)
-	webBuildArgs = V2ComposeFile.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})["build"].(map[interface{}]interface{})["arg"].([]interface{})
+	V2ComposeFileBuildArg.InjectBuildArgs(buildArgs)
+	webBuildArgs = V2ComposeFileBuildArg.Yaml["services"].(map[interface{}]interface{})["web"].(map[interface{}]interface{})["build"].(map[interface{}]interface{})["args"].([]interface{})
 
 	oldBuildArgtring := "FOO=hoge"
 	newBuildArgString := "FOO=hogefugapiyo"

--- a/receiver/fixtures/docker-compose-v2-buildarg.yml
+++ b/receiver/fixtures/docker-compose-v2-buildarg.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  db:
+    image: postgres:9.4
+    ports:
+      - "5432:5432"
+  web:
+    build:
+      context: .
+      args:
+        - FOO=bar
+    command: bin/rails s -p 8080 -b '0.0.0.0'
+    environment:
+      - DATABASE_HOST=db
+      - DATABASE_PORT=5432
+      - DATABASE_USER=postgres
+    ports:
+      - "80:8080"
+    links:
+      - db

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -297,6 +297,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = injectBuildArgs(application, composeFile, etcd); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	if err = injectEnvironmentVariables(application, composeFile, etcd); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
## WHY

When I tried to deploy application using build-time variables, it ignored registered build-time variable and failed deploy.
Unfortunally, the method to inject build-time variables was not called from anywhere...
## WHAT

Call injection method actually. Fix some bugs and add test around build-time variables.
