### PR TITLE
Put base64-encoded dockercfg

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,13 @@ if [ -n "$PAUS_REPOSITORY_DIR" ]; then
   chown -R git:git $PAUS_REPOSITORY_DIR
 fi
 
+if [ -n "$PAUS_DOCKER_CONFIG_BASE64" ]; then
+  if [ ! -d /home/git/.docker ]; then
+    mkdir /home/git/.docker
+  fi
+
+  echo $PAUS_DOCKRE_CONFIG_BASE64 | base64 -d > /home/git/.docker/config.json
+  chown -R git /home/git/.docker
+fi
+
 exec $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ if [ -n "$PAUS_DOCKER_CONFIG_BASE64" ]; then
     mkdir /home/git/.docker
   fi
 
-  echo $PAUS_DOCKRE_CONFIG_BASE64 | base64 -d > /home/git/.docker/config.json
+  echo $PAUS_DOCKER_CONFIG_BASE64 | base64 -d > /home/git/.docker/config.json
   chown -R git /home/git/.docker
 fi
 


### PR DESCRIPTION
## WHY

Pulling private repository fails due to lack of permission.

```
Pulling private-repo (dtan4/private-repo:latest)...
Error: Status 403 trying to pull repository dtan4/private-repo: "{\"error\": \"Permission Denied\"}"
remote: exit status 1
```
## WHAT

Put base64-encoded `.dockercfg` at first.
