### PR TITLE
Remove overlay network options

### DIFF
--- a/receiver/compose.go
+++ b/receiver/compose.go
@@ -59,7 +59,7 @@ func NewCompose(dockerHost, composeFilePath, projectName string) *Compose {
 }
 
 func (c *Compose) Build() error {
-	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "--x-networking", "--x-network-driver", "overlay", "build")
+	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "build")
 	cmd.Env = append(os.Environ(), "DOCKER_HOST="+c.dockerHost)
 
 	if err := runCommand(cmd); err != nil {
@@ -70,7 +70,7 @@ func (c *Compose) Build() error {
 }
 
 func (c *Compose) GetContainerId(service string) (string, error) {
-	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "--x-networking", "--x-network-driver", "overlay", "ps", "-q", service)
+	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "ps", "-q", service)
 	cmd.Env = append(os.Environ(), "DOCKER_HOST="+c.dockerHost)
 	out, err := cmd.Output()
 
@@ -82,7 +82,7 @@ func (c *Compose) GetContainerId(service string) (string, error) {
 }
 
 func (c *Compose) Pull() error {
-	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "--x-networking", "--x-network-driver", "overlay", "pull")
+	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "pull")
 	cmd.Env = append(os.Environ(), "DOCKER_HOST="+c.dockerHost)
 
 	if err := runCommand(cmd); err != nil {
@@ -93,7 +93,7 @@ func (c *Compose) Pull() error {
 }
 
 func (c *Compose) Up() error {
-	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "--x-networking", "--x-network-driver", "overlay", "up", "-d")
+	cmd := exec.Command("docker-compose", "-f", c.composeFilePath, "-p", c.projectName, "up", "-d")
 	cmd.Env = append(os.Environ(), "DOCKER_HOST="+c.dockerHost)
 
 	if err := runCommand(cmd); err != nil {


### PR DESCRIPTION
## WHY

`--x-networking` and `--x-network-driver` options no longer exists at the latest version.

https://github.com/docker/compose/blob/master/CHANGELOG.md#160-2016-01-15

> The experimental flags --x-networking and --x-network-driver, introduced in Compose 1.5, have been removed.
## WHAT

Remove these options.
