### PR TITLE
Rename application directory key

### DIFF
--- a/receiver/main.go
+++ b/receiver/main.go
@@ -52,7 +52,7 @@ func injectBuildArgs(application *Application, composeFile *ComposeFile, etcd *E
 		return nil
 	}
 
-	appDirectoryKey := userDirectoryKey + "/" + application.AppName
+	appDirectoryKey := userDirectoryKey + "/apps/" + application.AppName
 
 	if !etcd.HasKey(appDirectoryKey) {
 		return nil
@@ -94,7 +94,7 @@ func injectEnvironmentVariables(application *Application, composeFile *ComposeFi
 		return nil
 	}
 
-	appDirectoryKey := userDirectoryKey + "/" + application.AppName
+	appDirectoryKey := userDirectoryKey + "/apps/" + application.AppName
 
 	if !etcd.HasKey(appDirectoryKey) {
 		return nil
@@ -136,7 +136,7 @@ func registerApplicationMetadata(application *Application, etcd *Etcd) error {
 		_ = etcd.Mkdir(userDirectoryKey)
 	}
 
-	appDirectoryKey := userDirectoryKey + "/" + application.AppName
+	appDirectoryKey := userDirectoryKey + "/apps/" + application.AppName
 
 	if !etcd.HasKey(appDirectoryKey) {
 		_ = etcd.Mkdir(appDirectoryKey)


### PR DESCRIPTION
## WHY

Probably other resources except applications will be added.
## WHAT

Move application directory under `/paus/users/:username/apps/:appName` .
