### PR TITLE
Set X-Forwarded-Host, X-Forwarded-Proto header for appropriate redirection

### DIFF
--- a/receiver/main.go
+++ b/receiver/main.go
@@ -194,26 +194,26 @@ func registerVulcandInformation(application *Application, baseDomain string, web
 		return errors.Wrap(err, "Failed to set vulcand backend server.")
 	}
 
-	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$PROJECT_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)"}
+	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$PROJECT_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)", \"Settings\": {\"TrustForwardHeader\": true}}
 	if err := etcd.Set(
 		vulcandDirectoryKeyBase+"/frontends/"+application.ProjectName+"/frontend",
-		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.ProjectName+"."+baseDomain+"`) && PathRegexp(`/`)\"}",
+		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.ProjectName+"."+baseDomain+"`) && PathRegexp(`/`)\", \"Settings\": {\"TrustForwardHeader\": true}}",
 	); err != nil {
 		return errors.Wrap(err, "Failed to set vulcand frontend with project name.")
 	}
 
-	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$USER_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)"}
+	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$USER_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)", \"Settings\": {\"TrustForwardHeader\": true}}
 	if err := etcd.Set(
 		vulcandDirectoryKeyBase+"/frontends/"+application.Username+"/frontend",
-		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.Username+"."+baseDomain+"`) && PathRegexp(`/`)\"}",
+		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.Username+"."+baseDomain+"`) && PathRegexp(`/`)\", \"Settings\": {\"TrustForwardHeader\": true}}",
 	); err != nil {
 		return errors.Wrap(err, "Failed to set vulcand frontend with username.")
 	}
 
-	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$APP_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)"}
+	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$APP_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)", \"Settings\": {\"TrustForwardHeader\": true}}
 	if err := etcd.Set(
 		vulcandDirectoryKeyBase+"/frontends/"+application.AppName+"/frontend",
-		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.AppName+"."+baseDomain+"`) && PathRegexp(`/`)\"}",
+		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.AppName+"."+baseDomain+"`) && PathRegexp(`/`)\", \"Settings\": {\"TrustForwardHeader\": true}}",
 	); err != nil {
 		return errors.Wrap(err, "Failed to set vulcand frontend with appName.")
 	}


### PR DESCRIPTION
## WHY

If paus cluster is launched in HTTPS environment, Rails returns HTTP URL even if the request source URL is HTTPS.
To avoid this, we have to set original hostname in `X-Forwarded-Host` header and original URI scheme in `X-Forwarded-Proto`.
## WHAT

Add setting `TrustForwardHeader: true` to pass the original hostname to `X-Forwarded-Host` header and the original URI scheme to `X-Forwarded-Proto`.
## REF
- https://github.com/vulcand/vulcand/blob/475540bb016702d5b7cc4674e37f48ee3e144a69/vctl/command/frontend.go#L126
- https://github.com/vulcand/vulcand/blob/475540bb016702d5b7cc4674e37f48ee3e144a69/vendor/github.com/vulcand/oxy/forward/rewrite.go#L27-L39
