### PR TITLE
Modify application URL construction

### DIFF
--- a/receiver/main.go
+++ b/receiver/main.go
@@ -396,9 +396,9 @@ func main() {
 	}
 
 	urlList := []string{
-		uriScheme + "://" + application.ProjectName + "." + config.BaseDomain,
-		uriScheme + "://" + application.Username + "." + config.BaseDomain,
-		uriScheme + "://" + application.AppName + "." + config.BaseDomain,
+		uriScheme + "://" + application.ProjectName + "." + config.BaseDomain, // http://dtan4-docker-service-rails-a7f955b4.pausapp.com
+		uriScheme + "://" + application.Username + "." + config.BaseDomain,    // http://dtan4.pausapp.com
+		uriScheme + "://" + application.AppName + "." + config.BaseDomain,     // http://docker-service-rails.pausapp.com
 	}
 
 	fmt.Println("=====> " + application.Repository + " was successfully deployed at:")

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -396,9 +396,9 @@ func main() {
 	}
 
 	urlList := []string{
-		uriScheme + "://" + application.ProjectName + "." + config.BaseDomain, // http://dtan4-docker-service-rails-a7f955b4.pausapp.com
-		uriScheme + "://" + application.Username + "." + config.BaseDomain,    // http://dtan4.pausapp.com
-		uriScheme + "://" + application.AppName + "." + config.BaseDomain,     // http://docker-service-rails.pausapp.com
+		fmt.Sprintf("%s://%s.%s", uriScheme, application.ProjectName, config.BaseDomain), // http://dtan4-docker-service-rails-a7f955b4.pausapp.com
+		fmt.Sprintf("%s://%s.%s", uriScheme, application.Username, config.BaseDomain),    // http://dtan4.pausapp.com
+		fmt.Sprintf("%s://%s.%s", uriScheme, application.AppName, config.BaseDomain),     // http://docker-service-rails.pausapp.com
 	}
 
 	fmt.Println("=====> " + application.Repository + " was successfully deployed at:")

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -373,8 +373,8 @@ func main() {
 	}
 
 	urlList := []string{
-		fmt.Sprintf("%s://%s.%s", uriScheme, application.ProjectName, config.BaseDomain),                      // http://dtan4-docker-service-rails-a7f955b4.pausapp.com
-		fmt.Sprintf("%s://%s-%s.%s", uriScheme, application.Username, application.AppName, config.BaseDomain), // http://dtan4-docker-service-rails.pausapp.com
+		uriScheme + "://" + application.ProjectName + "." + config.BaseDomain,
+		uriScheme + "://" + application.Username + "." + application.AppName + "." + config.BaseDomain,
 	}
 
 	fmt.Println("=====> " + application.Repository + " was successfully deployed at:")

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -202,20 +202,12 @@ func registerVulcandInformation(application *Application, baseDomain string, web
 		return errors.Wrap(err, "Failed to set vulcand frontend with project name.")
 	}
 
-	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$USER_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)", \"Settings\": {\"TrustForwardHeader\": true}}
+	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$USER_NAME-$APP_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)", \"Settings\": {\"TrustForwardHeader\": true}}
 	if err := etcd.Set(
 		vulcandDirectoryKeyBase+"/frontends/"+application.Username+"/frontend",
-		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.Username+"."+baseDomain+"`) && PathRegexp(`/`)\", \"Settings\": {\"TrustForwardHeader\": true}}",
+		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.Username+"-"+application.AppName+"."+baseDomain+"`) && PathRegexp(`/`)\", \"Settings\": {\"TrustForwardHeader\": true}}",
 	); err != nil {
-		return errors.Wrap(err, "Failed to set vulcand frontend with username.")
-	}
-
-	// {"Type": "http", "BackendId": "$PROJECT_NAME", "Route": "Host(`$APP_NAME.$BASE_DOMAIN`) && PathRegexp(`/`)", \"Settings\": {\"TrustForwardHeader\": true}}
-	if err := etcd.Set(
-		vulcandDirectoryKeyBase+"/frontends/"+application.AppName+"/frontend",
-		"{\"Type\": \"http\", \"BackendId\": \""+application.ProjectName+"\", \"Route\": \"Host(`"+application.AppName+"."+baseDomain+"`) && PathRegexp(`/`)\", \"Settings\": {\"TrustForwardHeader\": true}}",
-	); err != nil {
-		return errors.Wrap(err, "Failed to set vulcand frontend with appName.")
+		return errors.Wrap(err, "Failed to set vulcand frontend with username-appname.")
 	}
 
 	return nil

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -396,9 +396,8 @@ func main() {
 	}
 
 	urlList := []string{
-		fmt.Sprintf("%s://%s.%s", uriScheme, application.ProjectName, config.BaseDomain), // http://dtan4-docker-service-rails-a7f955b4.pausapp.com
-		fmt.Sprintf("%s://%s.%s", uriScheme, application.Username, config.BaseDomain),    // http://dtan4.pausapp.com
-		fmt.Sprintf("%s://%s.%s", uriScheme, application.AppName, config.BaseDomain),     // http://docker-service-rails.pausapp.com
+		fmt.Sprintf("%s://%s.%s", uriScheme, application.ProjectName, config.BaseDomain),                      // http://dtan4-docker-service-rails-a7f955b4.pausapp.com
+		fmt.Sprintf("%s://%s-%s.%s", uriScheme, application.Username, application.AppName, config.BaseDomain), // http://dtan4-docker-service-rails.pausapp.com
 	}
 
 	fmt.Println("=====> " + application.Repository + " was successfully deployed at:")

--- a/receiver/vulcand.go
+++ b/receiver/vulcand.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	VulcandKeyBase = "/vulcand"
+)
+
+var (
+	httpBackendJSON string
+)
+
+type Vulcand struct {
+	etcd *Etcd
+}
+
+type VulcandBackend struct {
+	Type string `json:"Type"`
+}
+
+type VulcandServer struct {
+	URL string `json:"URL"`
+}
+
+type VulcandFrontend struct {
+	Type      string                  `json:"Type"`
+	BackendId string                  `json:"BackendId"`
+	Route     string                  `json:"Route"`
+	Settings  VulcandFrontendSettings `json:"Settings"`
+}
+
+type VulcandFrontendSettings struct {
+	TrustForwardHeader bool `json:"TrustForwardHeader"`
+}
+
+func NewVulcand(etcd *Etcd) *Vulcand {
+	backend := VulcandBackend{
+		Type: "http",
+	}
+
+	b, _ := json.Marshal(backend)
+	httpBackendJSON = string(b)
+
+	return &Vulcand{
+		etcd: etcd,
+	}
+}
+
+// {"Type": "http"}
+func (v *Vulcand) SetBackend(application *Application, baseDomain string) error {
+	key := fmt.Sprintf("%s/backends/%s/backend", VulcandKeyBase, application.ProjectName)
+
+	if err := v.etcd.Set(key, httpBackendJSON); err != nil {
+		return errors.Wrap(err, "Failed to set vulcand backend in etcd.")
+	}
+
+	return nil
+}
+
+// {"Type": "http", "BackendId": "$identifier", "Route": "Host(`$identifier.$base_domain`) && PathRegexp(`/`)", "Settings": {"TrustForwardHeader": true}}
+func (v *Vulcand) SetFrontend(application *Application, identifier, baseDomain string) error {
+	key := fmt.Sprintf("%s/frontends/%s/frontend", VulcandKeyBase, identifier)
+	frontend := VulcandFrontend{
+		Type:      "http",
+		BackendId: application.ProjectName,
+		Route:     fmt.Sprintf("Host(`%s.%s`) && PathRegexp(`/`)", identifier, baseDomain),
+		Settings: VulcandFrontendSettings{
+			TrustForwardHeader: true,
+		},
+	}
+
+	b, err := json.Marshal(frontend)
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to generate vulcand frontend JSON.")
+	}
+
+	json := string(b)
+
+	if err := v.etcd.Set(key, json); err != nil {
+		return errors.Wrap(err, "Failed to set vulcand frontend in etcd.")
+	}
+
+	return nil
+}
+
+// {"URL": "http://$web_container_host_ip:$web_container_port"}
+func (v *Vulcand) SetServer(application *Application, container *Container, baseDomain string) error {
+	key := fmt.Sprintf("%s/backends/%s/servers/%s", VulcandKeyBase, application.ProjectName, container.ContainerId)
+	server := VulcandServer{
+		URL: fmt.Sprintf("http://%s:%s", container.HostIP(), container.HostPort()),
+	}
+
+	b, err := json.Marshal(server)
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to generate vulcand server JSON.")
+	}
+
+	json := string(b)
+
+	if err := v.etcd.Set(key, json); err != nil {
+		return errors.Wrap(err, "Failed to set vulcand server in etcd.")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## WHY

URL generate logic is so complicated.
## WHAT

Generate two URLs per deploy:
- `http(s)://<username>-<appname>-<commithash>.domain`
- `http(s)://<username>-<appname>.domain`

Separate logic which registering Vulcand data.
