### PR TITLE
Add deploy limit and stop the oldest deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/id_rsa.pub

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ compose-up: compose-stop
 	@docker-compose run --rm gitreceive-upload-key $(PAUS_USER) "$(shell cat $(SSH_PUBLIC_KEY))"
 	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME) || true
 	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)/build-args || true
+	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)/deployments || true
 	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)/envs || true
-	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)/revisions || true
 
 .PHONY: compose-stop
 compose-stop:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,10 @@ compose-up: compose-stop
 	docker-compose build gitreceive gitreceive-upload-key
 	docker-compose up -d etcd gitreceive
 	@docker-compose run --rm gitreceive-upload-key $(PAUS_USER) "$(shell cat $(SSH_PUBLIC_KEY))"
-	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)  || true
+	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME) || true
+	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)/build-args || true
+	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)/envs || true
+	etcdctl --endpoint "http://$(DOCKER_HOST):2379" mkdir /paus/users/$(PAUS_USER)/apps/$(PAUS_APPNAME)/revisions || true
 
 .PHONY: compose-stop
 compose-stop:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ paus-gitreceive does:
 | `PAUS_BASE_DOMAIN`   | Required | Base domain for application URL                |                         | `pausapp.com`           |
 | `PAUS_DOCKER_HOST` |          | Endpoint of Docker daemon                       | `tcp://127.0.0.1:2375` | `tcp://127.0.0.1:2377` (Docker Swarm) |
 | `PAUS_ETCD_ENDPOINT` |          | Endpoint of etcd cluster                       | `http://127.0.0.1:2379` | `http://127.0.0.1:2379` |
+| `PAUS_MAX_APP_DEPLOY`    |          | Limitation of deploy count per applciation | `10`                   | `30`                  |
 | `PAUS_REPOSITORY_DIR`    |          | Directory to store repository files | `/repos`                   | `/repos`                  |
 | `PAUS_URI_SCHEME`        |          | URI scheme of application URL (`http`&#124;`https`) | `http`     | `http`                    |
 

--- a/coreos/config.rb
+++ b/coreos/config.rb
@@ -63,7 +63,7 @@ $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 #$image_version = "current"
 
 # Official CoreOS channel from which updates should be downloaded
-$update_channel='alpha'
+$update_channel='beta'
 
 # Log the serial consoles of CoreOS VMs to log/
 # Enable by setting value to true, disable with false

--- a/coreos/start.sh
+++ b/coreos/start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eu
+
+if [ ! -f id_rsa.pub ]; then
+  echo "id_rsa.pub does not exist!"
+  exit 1
+fi
+
+docker-compose -f docker-compose-coreos.yml stop || true
+docker-compose -f docker-compose-coreos.yml rm -f || true
+
+docker-compose -f docker-compose-coreos.yml build gitreceive gitreceive-upload-key
+docker-compose -f docker-compose-coreos.yml up -d gitreceive
+docker-compose run --rm gitreceive-upload-key $PAUS_USER "$(cat id_rsa.pub)"
+
+etcdctl rm /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/build-args/* || true
+etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/build-args || true
+
+etcdctl rm /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/deployments/* || true
+etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/deployments || true
+
+etcdctl rm /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/envs/* || true
+etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/envs || true
+
+etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME || true
+
+etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME || true
+etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/build-args || true
+etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/deployments || true
+etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/envs || true

--- a/coreos/start.sh
+++ b/coreos/start.sh
@@ -14,13 +14,13 @@ docker-compose -f docker-compose-coreos.yml build gitreceive gitreceive-upload-k
 docker-compose -f docker-compose-coreos.yml up -d gitreceive
 docker-compose run --rm gitreceive-upload-key $PAUS_USER "$(cat id_rsa.pub)"
 
-etcdctl rm /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/build-args/* || true
+etcdctl ls --recursive /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/build-args/ | xargs -r etcdctl rm || true
 etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/build-args || true
 
-etcdctl rm /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/deployments/* || true
+etcdctl ls --recursive /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/deployments/ | xargs -r etcdctl rm || true
 etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/deployments || true
 
-etcdctl rm /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/envs/* || true
+etcdctl ls --recursive /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/envs/ | xargs -r etcdctl rm || true
 etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/envs || true
 
 etcdctl rmdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME || true
@@ -29,3 +29,5 @@ etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME || true
 etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/build-args || true
 etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/deployments || true
 etcdctl mkdir /paus/users/$PAUS_USER/apps/$PAUS_APPNAME/envs || true
+
+docker ps | grep -v gitreceive | grep -v IMAGE | awk '{ print $1 }' | xargs -r docker stop | xargs -r docker rm || true

--- a/coreos/user-data.yml.erb
+++ b/coreos/user-data.yml.erb
@@ -23,7 +23,7 @@ coreos:
         Description=Set the timezone
 
         [Service]
-        ExecStart=/usr/bin/timedatectl set-timezone <%= ENV["TIMEZONE"] %>
+        ExecStart=/usr/bin/timedatectl set-timezone Asia/Tokyo
         RemainAfterExit=yes
         Type=oneshot
     - name: docker-tcp.socket
@@ -48,7 +48,7 @@ coreos:
 
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /opt/bin
-        ExecStart=/usr/bin/wget https://github.com/docker/compose/releases/download/<%= ENV["DOCKER_COMPOSE_VERSION"] %>/docker-compose-Linux-x86_64 -O /opt/bin/docker-compose
+        ExecStart=/usr/bin/wget https://github.com/docker/compose/releases/download/1.7.1/docker-compose-Linux-x86_64 -O /opt/bin/docker-compose
         ExecStartPost=/usr/bin/chown root:root /opt/bin/docker-compose
         ExecStartPost=/usr/bin/chmod +x /opt/bin/docker-compose
         RemainAfterExit=yes

--- a/docker-compose-coreos.yml
+++ b/docker-compose-coreos.yml
@@ -1,0 +1,22 @@
+version: '2'
+services:
+  gitreceive:
+    build:
+      context: .
+      dockerfile: Dockerfile.release
+    ports:
+      - "2222:22"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - PAUS_BASE_DOMAIN=pausapp.com
+      - PAUS_DOCKER_HOST=tcp://172.17.8.101:2375
+      - PAUS_ETCD_ENDPOINT=http://172.17.8.101:2379
+      - PAUS_MAX_APP_DEPLOY=0
+      - PAUS_REPOSITORY_DIR=/repos
+      - PAUS_URI_SCHEME=http
+  gitreceive-upload-key:
+    extends: gitreceive
+    volumes_from:
+      - gitreceive
+    entrypoint: /usr/local/bin/upload-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - PAUS_BASE_DOMAIN=pausapp.com
       - PAUS_DOCKER_HOST=unix:///var/run/docker.sock
       - PAUS_ETCD_ENDPOINT=http://etcd:2379
+      - PAUS_MAX_APP_DEPLOY=0
       - PAUS_REPOSITORY_DIR=/repos
       - PAUS_URI_SCHEME=http
   gitreceive-upload-key:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,10 @@ if [ -n "$PAUS_ETCD_ENDPOINT" ]; then
   echo "EtcdEndpoint=$PAUS_ETCD_ENDPOINT" >> /paus/config
 fi
 
+if [ -n "$PAUS_MAX_APP_DEPLOY" ]; then
+  echo "MaxAppDeploy=$PAUS_MAX_APP_DEPLOY" >> /paus/config
+fi
+
 if [ -n "$PAUS_REPOSITORY_DIR" ]; then
   echo "RepositoryDir=$PAUS_REPOSITORY_DIR" >> /paus/config
   chown -R git:git $PAUS_REPOSITORY_DIR

--- a/receiver/config/config.go
+++ b/receiver/config/config.go
@@ -20,6 +20,7 @@ var (
 		"BaseDomain",
 		"DockerHost",
 		"EtcdEndpoint",
+		"MaxAppDeploy",
 		"RepositoryDir",
 		"URIScheme",
 	}
@@ -29,6 +30,7 @@ type Config struct {
 	BaseDomain    string `envconfig:"base_domain"`
 	DockerHost    string `envconfig:"docker_host"    default:"tcp://localhost:2375"`
 	EtcdEndpoint  string `envconfig:"etcd_endpoint"  default:"http://localhost:2379"`
+	MaxAppDeploy  int64  `envconfig:"max_app_deploy" default:"10"`
 	RepositoryDir string `envconfig:"repository_dir" default:"/repos"`
 	URIScheme     string `envconfig:"uri_scheme"     default:"http"`
 }

--- a/receiver/config/config.go
+++ b/receiver/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/kelseyhightower/envconfig"
@@ -83,7 +84,17 @@ func LoadConfig() (*Config, error) {
 	}
 
 	for _, configName := range configNames {
-		reflect.ValueOf(&config).Elem().FieldByName(configName).SetString(configFromFile[configName])
+		if configName == "MaxAppDeploy" {
+			n, err := strconv.ParseInt(configFromFile[configName], 10, 64)
+
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to parse %s as integer. value: %s", configName, configFromFile[configName])
+			}
+
+			reflect.ValueOf(&config).Elem().FieldByName(configName).SetInt(n)
+		} else {
+			reflect.ValueOf(&config).Elem().FieldByName(configName).SetString(configFromFile[configName])
+		}
 	}
 
 	return &config, nil

--- a/receiver/config/config.go
+++ b/receiver/config/config.go
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	ConfigPrefix   = "paus"
-	ConfigFilePath = "/paus/config"
+	configPrefix   = "paus"
+	configFilePath = "/paus/config"
 )
 
 var (
-	ConfigNames = []string{
+	configNames = []string{
 		"BaseDomain",
 		"DockerHost",
 		"EtcdEndpoint",
@@ -66,23 +66,23 @@ func loadConfigFromFile(filePath string) (map[string]string, error) {
 func LoadConfig() (*Config, error) {
 	var config Config
 
-	err := envconfig.Process(ConfigPrefix, &config)
+	err := envconfig.Process(configPrefix, &config)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to load config from envs.")
 	}
 
-	if _, err := os.Stat(ConfigFilePath); err != nil {
+	if _, err := os.Stat(configFilePath); err != nil {
 		return &config, nil
 	}
 
-	configFromFile, err := loadConfigFromFile(ConfigFilePath)
+	configFromFile, err := loadConfigFromFile(configFilePath)
 
 	if err != nil {
 		return nil, err
 	}
 
-	for _, configName := range ConfigNames {
+	for _, configName := range configNames {
 		reflect.ValueOf(&config).Elem().FieldByName(configName).SetString(configFromFile[configName])
 	}
 

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -105,8 +105,12 @@ func rotateDeployments(etcd *store.Etcd, application *model.Application, maxAppD
 		return nil
 	}
 
+	fmt.Println("=====> Max deploy limit reached.")
+
 	oldestTimestamp := util.SortKeys(deployments)[0]
 	oldestDeployment := model.NewDeployment(application, deployments[oldestTimestamp], oldestTimestamp, repositoryDir)
+
+	fmt.Println("=====> Stop " + oldestDeployment.Revision + " ...")
 
 	compose, err := model.NewCompose(dockerHost, oldestDeployment.ComposeFilePath, oldestDeployment.ProjectName)
 

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/dtan4/paus-gitreceive/receiver/config"
 	"github.com/dtan4/paus-gitreceive/receiver/model"
+	"github.com/dtan4/paus-gitreceive/receiver/store"
 	"github.com/dtan4/paus-gitreceive/receiver/util"
+	"github.com/dtan4/paus-gitreceive/receiver/vulcand"
 )
 
 func deploy(application *model.Application, compose *model.Compose) (string, error) {
@@ -94,7 +96,7 @@ func printDeployedURLs(repository string, config *config.Config, identifiers []s
 	}
 }
 
-func rotateDeployments(application *model.Application, maxAppDeploy int64, dockerHost string, repositoryDir string) error {
+func rotateDeployments(etcd *store.Etcd, application *model.Application, maxAppDeploy int64, dockerHost string, repositoryDir string) error {
 	deployments, err := application.Deployments()
 
 	if err != nil {
@@ -126,7 +128,9 @@ func rotateDeployments(application *model.Application, maxAppDeploy int64, docke
 		return err
 	}
 
-	// Remove Vulcand routing
+	if err := vulcand.DeregisterInformation(etcd, oldestDeployment); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/dtan4/paus-gitreceive/receiver/config"
@@ -66,23 +65,22 @@ func injectEnvironmentVariables(application *model.Application, compose *model.C
 	return nil
 }
 
-func prepareComposeFile(application *model.Application, compose *model.Compose, timestamp string) (string, error) {
+func prepareComposeFile(application *model.Application, deployment *model.Deployment, compose *model.Compose) error {
 	if err := injectBuildArgs(application, compose); err != nil {
-		return "", err
+		return err
 	}
 
 	if err := injectEnvironmentVariables(application, compose); err != nil {
-		return "", err
+		return err
 	}
 
 	compose.RewritePortBindings()
-	newComposeFilePath := filepath.Join(filepath.Dir(compose.ComposeFilePath), "docker-compose-"+timestamp+".yml")
 
-	if err := compose.SaveAs(newComposeFilePath); err != nil {
-		return "", err
+	if err := compose.SaveAs(deployment.ComposeFilePath); err != nil {
+		return err
 	}
 
-	return newComposeFilePath, nil
+	return nil
 }
 
 func printDeployedURLs(repository string, config *config.Config, identifiers []string) {

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -108,9 +108,9 @@ func rotateDeployments(etcd *store.Etcd, application *model.Application, maxAppD
 	}
 
 	oldestTimestamp := util.SortKeys(deployments)[0]
-	oldestDeployment := model.NewDeployment(application, deployments[oldestTimestamp], oldestTimestamp)
+	oldestDeployment := model.NewDeployment(application, deployments[oldestTimestamp], oldestTimestamp, repositoryDir)
 
-	compose, err := model.NewCompose(dockerHost, oldestDeployment.ComposeFilePath(repositoryDir), oldestDeployment.ProjectName())
+	compose, err := model.NewCompose(dockerHost, oldestDeployment.ComposeFilePath, oldestDeployment.ProjectName)
 
 	if err != nil {
 		return err

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -3,9 +3,7 @@ package main
 import (
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dtan4/paus-gitreceive/receiver/config"
 	"github.com/dtan4/paus-gitreceive/receiver/model"
@@ -65,7 +63,7 @@ func injectEnvironmentVariables(application *model.Application, compose *model.C
 	return nil
 }
 
-func prepareComposeFile(application *model.Application, compose *model.Compose) (string, error) {
+func prepareComposeFile(application *model.Application, compose *model.Compose, timestamp string) (string, error) {
 	if err := injectBuildArgs(application, compose); err != nil {
 		return "", err
 	}
@@ -75,7 +73,7 @@ func prepareComposeFile(application *model.Application, compose *model.Compose) 
 	}
 
 	compose.RewritePortBindings()
-	newComposeFilePath := filepath.Join(filepath.Dir(compose.ComposeFilePath), "docker-compose-"+strconv.FormatInt(time.Now().Unix(), 10)+".yml")
+	newComposeFilePath := filepath.Join(filepath.Dir(compose.ComposeFilePath), "docker-compose-"+timestamp+".yml")
 
 	if err := compose.SaveAs(newComposeFilePath); err != nil {
 		return "", err

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -9,8 +9,18 @@ import (
 	"github.com/dtan4/paus-gitreceive/receiver/model"
 )
 
-func deploy(application *model.Application, compose *model.Compose) (string, error) {
+func deploy(application *model.Application, compose *model.Compose, maxAppDeploy int64) (string, error) {
 	var err error
+
+	revisions, err := application.Revisions()
+
+	if err != nil {
+		return "", err
+	}
+
+	if int64(len(revisions)) >= maxAppDeploy {
+		fmt.Println("Rate Limit Exceeded!!!!!!!!!!!!")
+	}
 
 	fmt.Println("=====> Building ...")
 

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -108,11 +108,7 @@ func rotateDeployments(etcd *store.Etcd, application *model.Application, maxAppD
 	}
 
 	oldestTimestamp := util.SortKeys(deployments)[0]
-	oldestDeployment := &model.Deployment{
-		App:       application,
-		Revision:  deployments[oldestTimestamp],
-		Timestamp: oldestTimestamp,
-	}
+	oldestDeployment := model.NewDeployment(application, deployments[oldestTimestamp], oldestTimestamp)
 
 	compose, err := model.NewCompose(dockerHost, oldestDeployment.ComposeFilePath(repositoryDir), oldestDeployment.ProjectName())
 

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	fmt.Println("=====> docker-compose.yml was found")
 
-	if err := rotateDeployments(application, config.MaxAppDeploy, config.DockerHost, repositoryPath); err != nil {
+	if err := rotateDeployments(application, config.MaxAppDeploy, config.DockerHost, config.RepositoryDir); err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -85,7 +85,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	newComposeFilePath, err := prepareComposeFile(application, compose)
+	timestamp := util.Timestamp()
+
+	newComposeFilePath, err := prepareComposeFile(application, compose, timestamp)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
@@ -110,7 +112,7 @@ func main() {
 
 	fmt.Println("=====> Registering metadata ...")
 
-	if err = application.RegisterMetadata(); err != nil {
+	if err = application.RegisterMetadata(timestamp); err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -98,9 +98,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	newComposeFilePath, err := prepareComposeFile(application, compose, timestamp)
-
-	if err != nil {
+	if err := prepareComposeFile(application, deployment, compose); err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}
@@ -137,7 +135,7 @@ func main() {
 
 	printDeployedURLs(application.Repository, config, identifiers)
 
-	if err = util.RemoveUnpackedFiles(repositoryPath, newComposeFilePath); err != nil {
+	if err = util.RemoveUnpackedFiles(repositoryPath, deployment.ComposeFilePath); err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -99,7 +99,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	webContainerID, err := deploy(application, compose)
+	webContainerID, err := deploy(application, compose, config.MaxAppDeploy)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -29,7 +29,12 @@ func initialize() (*config.Config, *store.Etcd, error) {
 }
 
 func main() {
-	// printVersion()
+	if len(os.Args) > 1 {
+		if os.Args[1] == "-v" || os.Args[1] == "--version" {
+			printVersion()
+			os.Exit(0)
+		}
+	}
 
 	config, etcd, err := initialize()
 

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -83,6 +83,11 @@ func main() {
 
 	fmt.Println("=====> docker-compose.yml was found")
 
+	if err := rotateDeployments(application, config.MaxAppDeploy, config.DockerHost, repositoryPath); err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(1)
+	}
+
 	compose, err := model.NewCompose(config.DockerHost, composeFilePath, application.ProjectName)
 
 	if err != nil {
@@ -99,7 +104,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	webContainerID, err := deploy(application, compose, config.MaxAppDeploy)
+	webContainerID, err := deploy(application, compose)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	fmt.Println("=====> docker-compose.yml was found")
 
-	if err := rotateDeployments(application, config.MaxAppDeploy, config.DockerHost, config.RepositoryDir); err != nil {
+	if err := rotateDeployments(etcd, application, config.MaxAppDeploy, config.DockerHost, config.RepositoryDir); err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}

--- a/receiver/model/application.go
+++ b/receiver/model/application.go
@@ -1,9 +1,7 @@
 package model
 
 import (
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dtan4/paus-gitreceive/receiver/store"
 	"github.com/pkg/errors"
@@ -123,7 +121,7 @@ func (app *Application) EnvironmentVariables() (map[string]string, error) {
 	return envs, nil
 }
 
-func (app *Application) RegisterMetadata() error {
+func (app *Application) RegisterMetadata(timestamp string) error {
 	userDirectoryKey := "/paus/users/" + app.Username
 
 	if !app.etcd.HasKey(userDirectoryKey) {
@@ -138,7 +136,7 @@ func (app *Application) RegisterMetadata() error {
 		_ = app.etcd.Mkdir(appDirectoryKey + "/revisions")
 	}
 
-	if err := app.etcd.Set(appDirectoryKey+"/revisions/"+app.Revision, strconv.FormatInt(time.Now().Unix(), 10)); err != nil {
+	if err := app.etcd.Set(appDirectoryKey+"/revisions/"+app.Revision, timestamp); err != nil {
 		return err
 	}
 

--- a/receiver/model/application.go
+++ b/receiver/model/application.go
@@ -78,6 +78,39 @@ func (app *Application) BuildArgs() (map[string]string, error) {
 	return args, nil
 }
 
+func (app *Application) DeleteDeployment(deployment string) error {
+	key := "/paus/users/" + app.Username + "/apps/" + app.AppName + "/deployments/" + deployment
+
+	if err := app.etcd.Delete(key); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (app *Application) Deployments() (map[string]string, error) {
+	var deployments = make(map[string]string)
+
+	deploymentsKey := "/paus/users/" + app.Username + "/apps/" + app.AppName + "/deployments/"
+	keys, err := app.etcd.List(deploymentsKey, false)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range keys {
+		value, err := app.etcd.Get(key)
+
+		if err != nil {
+			return nil, err
+		}
+
+		deployments[strings.Replace(key, deploymentsKey, "", 1)] = value
+	}
+
+	return deployments, nil
+}
+
 func (app *Application) DirExists() bool {
 	return app.etcd.HasKey("/paus/users/" + app.Username + "/apps/" + app.AppName)
 }
@@ -133,24 +166,13 @@ func (app *Application) RegisterMetadata(timestamp string) error {
 
 	if !app.etcd.HasKey(appDirectoryKey) {
 		_ = app.etcd.Mkdir(appDirectoryKey)
+		_ = app.etcd.Mkdir(appDirectoryKey + "/deployments")
 		_ = app.etcd.Mkdir(appDirectoryKey + "/envs")
-		_ = app.etcd.Mkdir(appDirectoryKey + "/revisions")
 	}
 
-	if err := app.etcd.Set(appDirectoryKey+"/revisions/"+app.Revision, timestamp); err != nil {
+	if err := app.etcd.Set(appDirectoryKey+"/deployments/"+timestamp, app.Revision); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (app *Application) Revisions() ([]string, error) {
-	revisionsKey := "/paus/users/" + app.Username + "/apps/" + app.AppName + "/revisions"
-	keys, err := app.etcd.List(revisionsKey, false)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return keys, err
 }

--- a/receiver/model/application.go
+++ b/receiver/model/application.go
@@ -13,7 +13,8 @@ type Application struct {
 	Username    string
 	AppName     string
 	ProjectName string
-	etcd        *store.Etcd
+
+	etcd *store.Etcd
 }
 
 func ApplicationFromArgs(args []string, etcd *store.Etcd) (*Application, error) {
@@ -141,4 +142,15 @@ func (app *Application) RegisterMetadata(timestamp string) error {
 	}
 
 	return nil
+}
+
+func (app *Application) Revisions() ([]string, error) {
+	revisionsKey := "/paus/users/" + app.Username + "/apps/" + app.AppName + "/revisions"
+	keys, err := app.etcd.List(revisionsKey, false)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return keys, err
 }

--- a/receiver/model/application_test.go
+++ b/receiver/model/application_test.go
@@ -25,10 +25,8 @@ func TestApplicationFromArgs(t *testing.T) {
 	}
 
 	expectedRepository := "dtan4-rails-sample"
-	expectedRevision := "3e634e41d5a819a7586c621a6322ee4d5085232c"
 	expectedUsername := "dtan4"
 	expectedAppName := "rails-sample"
-	expectedProjectName := "dtan4-rails-sample-3e634e41"
 
 	application, err := ApplicationFromArgs(args, etcd)
 
@@ -40,19 +38,11 @@ func TestApplicationFromArgs(t *testing.T) {
 		t.Fatalf("Repository is not matched. Expected: %s, Actual: %s", expectedRepository, application.Repository)
 	}
 
-	if expectedRevision != application.Revision {
-		t.Fatalf("Revision is not matched. Expected: %s, Actual: %s", expectedRevision, application.Revision)
-	}
-
 	if expectedUsername != application.Username {
 		t.Fatalf("Username is not matched. Expected: %s, Actual: %s", expectedUsername, application.Username)
 	}
 
 	if expectedAppName != application.AppName {
 		t.Fatalf("AppName is not matched. Expected: %s, Actual: %s", expectedAppName, application.AppName)
-	}
-
-	if expectedProjectName != application.ProjectName {
-		t.Fatalf("ProjectName is not matched. Expected: %s, Actual: %s", expectedProjectName, application.ProjectName)
 	}
 }

--- a/receiver/model/compose.go
+++ b/receiver/model/compose.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -39,10 +38,6 @@ type ComposeConfig struct {
 	Services map[string]*config.ServiceConfig `yaml:"services,omitempty"`
 	Volumes  map[string]*config.VolumeConfig  `yaml:"volumes,omitempty"`
 	Networks map[string]*config.NetworkConfig `yaml:"networks,omitempty"`
-}
-
-func ComposeFilePath(dir string, timestamp string) string {
-	return filepath.Join(dir, "docker-compose-"+timestamp+".yml")
 }
 
 func NewCompose(dockerHost, composeFilePath, projectName string) (*Compose, error) {

--- a/receiver/model/deployment.go
+++ b/receiver/model/deployment.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"path/filepath"
+)
+
+type Deployment struct {
+	App       *Application
+	Revision  string
+	Timestamp string
+}
+
+func (d *Deployment) ComposeFilePath(repositoryDir string) string {
+	return filepath.Join(repositoryDir, d.App.Username, d.ProjectName(), "docker-compose-"+d.Timestamp+".yml")
+}
+
+func (d *Deployment) ProjectName() string {
+	return d.App.Repository + "-" + d.Revision[0:8]
+}

--- a/receiver/model/deployment.go
+++ b/receiver/model/deployment.go
@@ -25,3 +25,7 @@ func NewDeployment(app *Application, revision, timestamp, repositoryDir string) 
 		Timestamp:       timestamp,
 	}
 }
+
+func (d *Deployment) Register() error {
+	return d.app.RegisterMetadata(d.Revision, d.Timestamp)
+}

--- a/receiver/model/deployment.go
+++ b/receiver/model/deployment.go
@@ -5,15 +5,24 @@ import (
 )
 
 type Deployment struct {
-	App       *Application
 	Revision  string
 	Timestamp string
+
+	app *Application
+}
+
+func NewDeployment(app *Application, revision, timestamp string) *Deployment {
+	return &Deployment{
+		app:       app,
+		Revision:  revision,
+		Timestamp: timestamp,
+	}
 }
 
 func (d *Deployment) ComposeFilePath(repositoryDir string) string {
-	return filepath.Join(repositoryDir, d.App.Username, d.ProjectName(), "docker-compose-"+d.Timestamp+".yml")
+	return filepath.Join(repositoryDir, d.app.Username, d.ProjectName(), "docker-compose-"+d.Timestamp+".yml")
 }
 
 func (d *Deployment) ProjectName() string {
-	return d.App.Repository + "-" + d.Revision[0:8]
+	return d.app.Repository + "-" + d.Revision[0:8]
 }

--- a/receiver/model/deployment.go
+++ b/receiver/model/deployment.go
@@ -5,24 +5,23 @@ import (
 )
 
 type Deployment struct {
-	Revision  string
-	Timestamp string
+	ComposeFilePath string
+	ProjectName     string
+	Revision        string
+	Timestamp       string
 
 	app *Application
 }
 
-func NewDeployment(app *Application, revision, timestamp string) *Deployment {
+func NewDeployment(app *Application, revision, timestamp, repositoryDir string) *Deployment {
+	projectName := app.Repository + "-" + revision[0:8]
+	composeFilePath := filepath.Join(repositoryDir, app.Username, projectName, "docker-compose-"+timestamp+".yml")
+
 	return &Deployment{
-		app:       app,
-		Revision:  revision,
-		Timestamp: timestamp,
+		app:             app,
+		ComposeFilePath: composeFilePath,
+		ProjectName:     projectName,
+		Revision:        revision,
+		Timestamp:       timestamp,
 	}
-}
-
-func (d *Deployment) ComposeFilePath(repositoryDir string) string {
-	return filepath.Join(repositoryDir, d.app.Username, d.ProjectName(), "docker-compose-"+d.Timestamp+".yml")
-}
-
-func (d *Deployment) ProjectName() string {
-	return d.app.Repository + "-" + d.Revision[0:8]
 }

--- a/receiver/model/deployment_test.go
+++ b/receiver/model/deployment_test.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestComposeFilePath(t *testing.T) {
+	application := &Application{
+		Repository: "user-repository",
+		Username:   "user",
+		AppName:    "app",
+	}
+
+	deployment := &Deployment{
+		App:       application,
+		Revision:  "19fb23cd71a4cf2eab00ad1a393e40de4ed61531",
+		Timestamp: "1467181319",
+	}
+
+	repositoryDir := "/repos"
+
+	expected := "/repos/user/user-repository-19fb23cd/docker-compose-1467181319.yml"
+	actual := deployment.ComposeFilePath(repositoryDir)
+
+	if actual != expected {
+		t.Fatalf("ComposeFilePath does not match. expected: %s actual: %s", expected, actual)
+	}
+}
+
+func TestProjectName(t *testing.T) {
+	application := &Application{
+		Repository: "user-repository",
+		Username:   "user",
+		AppName:    "app",
+	}
+
+	deployment := &Deployment{
+		App:       application,
+		Revision:  "19fb23cd71a4cf2eab00ad1a393e40de4ed61531",
+		Timestamp: "1467181319",
+	}
+
+	expected := "user-repository-19fb23cd"
+	actual := deployment.ProjectName()
+
+	if actual != expected {
+		t.Fatalf("ProjectName does not match. expected: %s actual: %s", expected, actual)
+	}
+}

--- a/receiver/model/deployment_test.go
+++ b/receiver/model/deployment_test.go
@@ -4,44 +4,33 @@ import (
 	"testing"
 )
 
-func TestComposeFilePath(t *testing.T) {
-	application := &Application{
+func TestNewDeployment(t *testing.T) {
+	var (
+		actual   string
+		expected string
+	)
+
+	app := &Application{
 		Repository: "user-repository",
 		Username:   "user",
 		AppName:    "app",
 	}
 
-	deployment := &Deployment{
-		App:       application,
-		Revision:  "19fb23cd71a4cf2eab00ad1a393e40de4ed61531",
-		Timestamp: "1467181319",
-	}
-
+	revision := "19fb23cd71a4cf2eab00ad1a393e40de4ed61531"
+	timestamp := "1467181319"
 	repositoryDir := "/repos"
 
-	expected := "/repos/user/user-repository-19fb23cd/docker-compose-1467181319.yml"
-	actual := deployment.ComposeFilePath(repositoryDir)
+	deployment := NewDeployment(app, revision, timestamp, repositoryDir)
+
+	expected = "/repos/user/user-repository-19fb23cd/docker-compose-1467181319.yml"
+	actual = deployment.ComposeFilePath
 
 	if actual != expected {
 		t.Fatalf("ComposeFilePath does not match. expected: %s actual: %s", expected, actual)
 	}
-}
 
-func TestProjectName(t *testing.T) {
-	application := &Application{
-		Repository: "user-repository",
-		Username:   "user",
-		AppName:    "app",
-	}
-
-	deployment := &Deployment{
-		App:       application,
-		Revision:  "19fb23cd71a4cf2eab00ad1a393e40de4ed61531",
-		Timestamp: "1467181319",
-	}
-
-	expected := "user-repository-19fb23cd"
-	actual := deployment.ProjectName()
+	expected = "user-repository-19fb23cd"
+	actual = deployment.ProjectName
 
 	if actual != expected {
 		t.Fatalf("ProjectName does not match. expected: %s actual: %s", expected, actual)

--- a/receiver/store/etcd.go
+++ b/receiver/store/etcd.go
@@ -46,7 +46,10 @@ func (c *Etcd) HasKey(key string) bool {
 func (c *Etcd) List(key string, recursive bool) ([]string, error) {
 	result := []string{}
 
-	resp, err := c.keysAPI.Get(context.Background(), key, &client.GetOptions{Recursive: recursive})
+	resp, err := c.keysAPI.Get(context.Background(), key, &client.GetOptions{
+		Recursive: recursive,
+		Sort:      true,
+	})
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to list up etcd keys. key: %s, recursive: %v", key, recursive)

--- a/receiver/store/etcd.go
+++ b/receiver/store/etcd.go
@@ -37,6 +37,19 @@ func (c *Etcd) Delete(key string) error {
 	return nil
 }
 
+func (c *Etcd) DeleteDir(key string, recursive bool) error {
+	_, err := c.keysAPI.Delete(context.Background(), key, &client.DeleteOptions{
+		Dir:       true,
+		Recursive: recursive,
+	})
+
+	if err != nil {
+		return errors.Wrapf(err, "Failed to delete etcd directory. key: %s, recursive: %t", key, recursive)
+	}
+
+	return nil
+}
+
 func (c *Etcd) Get(key string) (string, error) {
 	resp, err := c.keysAPI.Get(context.Background(), key, &client.GetOptions{})
 

--- a/receiver/store/etcd.go
+++ b/receiver/store/etcd.go
@@ -27,6 +27,16 @@ func NewEtcd(etcdEndpoint string) (*Etcd, error) {
 	return &Etcd{keysAPI}, nil
 }
 
+func (c *Etcd) Delete(key string) error {
+	_, err := c.keysAPI.Delete(context.Background(), key, &client.DeleteOptions{})
+
+	if err != nil {
+		return errors.Wrapf(err, "Failed to delete etcd entry. key: %s", key)
+	}
+
+	return nil
+}
+
 func (c *Etcd) Get(key string) (string, error) {
 	resp, err := c.keysAPI.Get(context.Background(), key, &client.GetOptions{})
 

--- a/receiver/util/util.go
+++ b/receiver/util/util.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -85,6 +87,10 @@ func RunCommand(cmd *exec.Cmd) error {
 	}
 
 	return nil
+}
+
+func Timestamp() string {
+	return strconv.FormatInt(time.Now().Unix(), 10)
 }
 
 func UnpackReceivedFiles(repositoryDir, username, projectName string, stdin io.Reader) (string, error) {

--- a/receiver/util/util.go
+++ b/receiver/util/util.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 
@@ -87,6 +88,18 @@ func RunCommand(cmd *exec.Cmd) error {
 	}
 
 	return nil
+}
+
+func SortKeys(kv map[string]string) []string {
+	var keys []string
+
+	for k, _ := range kv {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
 }
 
 func Timestamp() string {

--- a/receiver/vulcand/backend.go
+++ b/receiver/vulcand/backend.go
@@ -3,7 +3,6 @@ package vulcand
 import (
 	"fmt"
 
-	"github.com/dtan4/paus-gitreceive/receiver/model"
 	"github.com/dtan4/paus-gitreceive/receiver/store"
 )
 
@@ -16,10 +15,20 @@ type Backend struct {
 }
 
 // {"Type": "http"}
-func setBackend(etcd *store.Etcd, application *model.Application, baseDomain string) error {
-	key := fmt.Sprintf("%s/backends/%s/backend", vulcandKeyBase, application.ProjectName)
+func setBackend(etcd *store.Etcd, projectName string) error {
+	key := fmt.Sprintf("%s/backends/%s/backend", vulcandKeyBase, projectName)
 
 	if err := etcd.Set(key, httpBackendJSON); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unsetBackend(etcd *store.Etcd, projectName string) error {
+	key := fmt.Sprintf("%s/backends/%s/backend", vulcandKeyBase, projectName)
+
+	if err := etcd.Delete(key); err != nil {
 		return err
 	}
 

--- a/receiver/vulcand/frontend.go
+++ b/receiver/vulcand/frontend.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dtan4/paus-gitreceive/receiver/model"
 	"github.com/dtan4/paus-gitreceive/receiver/store"
 	"github.com/pkg/errors"
 )
@@ -23,11 +22,11 @@ type FrontendSettings struct {
 }
 
 // {"Type": "http", "BackendId": "$identifier", "Route": "Host(`$identifier.$base_domain`) && PathRegexp(`/`)", "Settings": {"TrustForwardHeader": true}}
-func setFrontend(etcd *store.Etcd, application *model.Application, identifier, baseDomain string) error {
+func setFrontend(etcd *store.Etcd, projectName, identifier, baseDomain string) error {
 	key := fmt.Sprintf("%s/frontends/%s/frontend", vulcandKeyBase, identifier)
 	frontend := Frontend{
 		Type:      "http",
-		BackendId: application.ProjectName,
+		BackendId: projectName,
 		Route:     fmt.Sprintf("Host(`%s.%s`) && PathRegexp(`/`)", strings.ToLower(identifier), strings.ToLower(baseDomain)),
 		Settings: FrontendSettings{
 			TrustForwardHeader: true,
@@ -45,6 +44,14 @@ func setFrontend(etcd *store.Etcd, application *model.Application, identifier, b
 	json := string(b)
 
 	if err := etcd.Set(key, json); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unsetFrontend(etcd *store.Etcd, identifier string) error {
+	if err := etcd.DeleteDir(fmt.Sprintf("%s/frontends/%s", vulcandKeyBase, identifier), true); err != nil {
 		return err
 	}
 

--- a/receiver/vulcand/server.go
+++ b/receiver/vulcand/server.go
@@ -14,8 +14,8 @@ type Server struct {
 }
 
 // {"URL": "http://$web_container_host_ip:$web_container_port"}
-func setServer(etcd *store.Etcd, application *model.Application, container *model.Container, baseDomain string) error {
-	key := fmt.Sprintf("%s/backends/%s/servers/%s", vulcandKeyBase, application.ProjectName, container.ContainerId)
+func setServer(etcd *store.Etcd, projectName string, container *model.Container, baseDomain string) error {
+	key := fmt.Sprintf("%s/backends/%s/servers/%s", vulcandKeyBase, projectName, container.ContainerId)
 	server := Server{
 		URL: fmt.Sprintf("http://%s:%s", container.HostIP(), container.HostPort()),
 	}
@@ -29,6 +29,16 @@ func setServer(etcd *store.Etcd, application *model.Application, container *mode
 	json := string(b)
 
 	if err := etcd.Set(key, json); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unsetServer(etcd *store.Etcd, projectName string) error {
+	key := fmt.Sprintf("%s/backends/%s/servers", vulcandKeyBase, projectName)
+
+	if err := etcd.DeleteDir(key, true); err != nil {
 		return err
 	}
 

--- a/receiver/vulcand/vulcand.go
+++ b/receiver/vulcand/vulcand.go
@@ -12,8 +12,26 @@ const (
 	vulcandKeyBase = "/vulcand"
 )
 
+func DeregisterInformation(etcd *store.Etcd, deployment *model.Deployment) error {
+	if err := unsetServer(etcd, deployment.ProjectName()); err != nil {
+		return err
+	}
+
+	identifier := strings.ToLower(deployment.ProjectName())
+
+	if err := unsetFrontend(etcd, identifier); err != nil {
+		return err
+	}
+
+	if err := unsetBackend(etcd, deployment.ProjectName()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func RegisterInformation(etcd *store.Etcd, application *model.Application, baseDomain string, webContainer *model.Container) ([]string, error) {
-	if err := setBackend(etcd, application, baseDomain); err != nil {
+	if err := setBackend(etcd, application.ProjectName); err != nil {
 		return nil, err
 	}
 
@@ -23,12 +41,12 @@ func RegisterInformation(etcd *store.Etcd, application *model.Application, baseD
 	}
 
 	for _, identifier := range identifiers {
-		if err := setFrontend(etcd, application, identifier, baseDomain); err != nil {
+		if err := setFrontend(etcd, application.ProjectName, identifier, baseDomain); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := setServer(etcd, application, webContainer, baseDomain); err != nil {
+	if err := setServer(etcd, application.ProjectName, webContainer, baseDomain); err != nil {
 		return nil, errors.Wrap(err, "Failed to set vulcand backend.")
 	}
 

--- a/receiver/vulcand/vulcand.go
+++ b/receiver/vulcand/vulcand.go
@@ -13,17 +13,17 @@ const (
 )
 
 func DeregisterInformation(etcd *store.Etcd, deployment *model.Deployment) error {
-	if err := unsetServer(etcd, deployment.ProjectName()); err != nil {
+	if err := unsetServer(etcd, deployment.ProjectName); err != nil {
 		return err
 	}
 
-	identifier := strings.ToLower(deployment.ProjectName())
+	identifier := strings.ToLower(deployment.ProjectName)
 
 	if err := unsetFrontend(etcd, identifier); err != nil {
 		return err
 	}
 
-	if err := unsetBackend(etcd, deployment.ProjectName()); err != nil {
+	if err := unsetBackend(etcd, deployment.ProjectName); err != nil {
 		return err
 	}
 

--- a/receiver/vulcand/vulcand.go
+++ b/receiver/vulcand/vulcand.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/dtan4/paus-gitreceive/receiver/model"
 	"github.com/dtan4/paus-gitreceive/receiver/store"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -30,24 +29,24 @@ func DeregisterInformation(etcd *store.Etcd, deployment *model.Deployment) error
 	return nil
 }
 
-func RegisterInformation(etcd *store.Etcd, application *model.Application, baseDomain string, webContainer *model.Container) ([]string, error) {
-	if err := setBackend(etcd, application.ProjectName); err != nil {
+func RegisterInformation(etcd *store.Etcd, application *model.Application, deployment *model.Deployment, baseDomain string, webContainer *model.Container) ([]string, error) {
+	if err := setBackend(etcd, deployment.ProjectName); err != nil {
 		return nil, err
 	}
 
 	identifiers := []string{
-		strings.ToLower(application.ProjectName),
+		strings.ToLower(deployment.ProjectName),
 		strings.ToLower(application.Username + "-" + application.AppName),
 	}
 
 	for _, identifier := range identifiers {
-		if err := setFrontend(etcd, application.ProjectName, identifier, baseDomain); err != nil {
+		if err := setFrontend(etcd, deployment.ProjectName, identifier, baseDomain); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := setServer(etcd, application.ProjectName, webContainer, baseDomain); err != nil {
-		return nil, errors.Wrap(err, "Failed to set vulcand backend.")
+	if err := setServer(etcd, deployment.ProjectName, webContainer, baseDomain); err != nil {
+		return nil, err
 	}
 
 	return identifiers, nil


### PR DESCRIPTION
To avoid the infinite resource increase, we have to set the maximum number of deployments per application.

This pull requrest includes the change of data structure: `revisions` is deprecated and replaced to `deployments`.
