### PR TITLE
Do healthcheck before completing deploy

### DIFF
--- a/receiver/main.go
+++ b/receiver/main.go
@@ -123,6 +123,25 @@ func main() {
 		os.Exit(1)
 	}
 
+	path, interval, maxTry, err := application.HealthCheck()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(1)
+	}
+
+	callback := func(path string, try int) {
+		fmt.Println(fmt.Sprintf("      Ping to %s (%d times) ...", path, try))
+	}
+
+	fmt.Println("=====> Start healthcheck ...")
+
+	if !webContainer.ExecuteHealthCheck(path, interval, maxTry, callback) {
+		fmt.Fprintln(os.Stderr, "=====> Web container is not active. Aborted.")
+		compose.Stop()
+		os.Exit(1)
+	}
+
 	fmt.Println("=====> Registering metadata ...")
 
 	deployment.Timestamp = util.Timestamp()

--- a/receiver/model/application.go
+++ b/receiver/model/application.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/dtan4/paus-gitreceive/receiver/store"
@@ -149,6 +150,37 @@ func (app *Application) EnvironmentVariables() (map[string]string, error) {
 	}
 
 	return envs, nil
+}
+
+func (app *Application) HealthCheck() (string, int, int, error) {
+	keyBase := "/paus/users/" + app.Username + "/apps/" + app.AppName + "/healthcheck"
+
+	path, err := app.etcd.Get(keyBase + "/path")
+	if err != nil {
+		return "", 0, 0, err
+	}
+
+	i, err := app.etcd.Get(keyBase + "/interval")
+	if err != nil {
+		return "", 0, 0, err
+	}
+
+	interval, err := strconv.Atoi(i)
+	if err != nil {
+		return "", 0, 0, err
+	}
+
+	m, err := app.etcd.Get(keyBase + "/max-try")
+	if err != nil {
+		return "", 0, 0, err
+	}
+
+	maxTry, err := strconv.Atoi(m)
+	if err != nil {
+		return "", 0, 0, err
+	}
+
+	return path, interval, maxTry, nil
 }
 
 func (app *Application) RegisterMetadata(revision, timestamp string) error {


### PR DESCRIPTION
## WHY

With large web application, we have to wait for some time until receiving the first response.
Sometimes we cannot access to web application though the deployment completed successfully.
## WHAT

Do healthcheck /warming up to the specified endpoint after launching container.
