### PR TITLE
Push to ECR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@
 !files/get-submodules
 !files/sshd_config
 !files/receiver
+!files/receiver-wrapper.sh
 !files/upload-key
 !receiver/bin/receiver_linux-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ COPY files/sshd_config /etc/ssh/
 
 RUN gitreceive init
 RUN echo "git:passwd" | chpasswd
-COPY receiver/bin/receiver_linux-amd64 /home/git/receiver
+COPY files/receiver-wrapper.sh /home/git/receiver
+COPY receiver/bin/receiver_linux-amd64 /usr/local/bin/receiver
 
 COPY files/get-submodules /usr/local/bin/
 COPY files/upload-key /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ paus-gitreceive does:
 | `PAUS_DOCKER_HOST` |          | Endpoint of Docker daemon                       | `tcp://127.0.0.1:2375` | `tcp://127.0.0.1:2377` (Docker Swarm) |
 | `PAUS_ETCD_ENDPOINT` |          | Endpoint of etcd cluster                       | `http://127.0.0.1:2379` | `http://127.0.0.1:2379` |
 | `PAUS_MAX_APP_DEPLOY`    |          | Max number of deployments per applciation | `10`                   | `30`                  |
+| `PAUS_REGISTRY_DOMAIN`    |          | Domain name of Docker Registry (Private Registry, ECR...) | `(empty)` | `012345678912.dkr.ecr.us-west-2.amazonaws.com` |
 | `PAUS_REPOSITORY_DIR`    |          | Directory to store repository files | `/repos`                   | `/repos`                  |
 | `PAUS_URI_SCHEME`        |          | URI scheme of application URL (`http`&#124;`https`) | `http`     | `http`                    |
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ paus-gitreceive does:
 | `PAUS_DOCKER_HOST` |          | Endpoint of Docker daemon                       | `tcp://127.0.0.1:2375` | `tcp://127.0.0.1:2377` (Docker Swarm) |
 | `PAUS_ETCD_ENDPOINT` |          | Endpoint of etcd cluster                       | `http://127.0.0.1:2379` | `http://127.0.0.1:2379` |
 | `PAUS_MAX_APP_DEPLOY`    |          | Max number of deployments per applciation | `10`                   | `30`                  |
-| `PAUS_REGISTRY_DOMAIN`    |          | Domain name of Docker Registry (Private Registry, ECR...) | `(empty)` | `012345678912.dkr.ecr.us-west-2.amazonaws.com` |
 | `PAUS_REPOSITORY_DIR`    |          | Directory to store repository files | `/repos`                   | `/repos`                  |
 | `PAUS_URI_SCHEME`        |          | URI scheme of application URL (`http`&#124;`https`) | `http`     | `http`                    |
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ paus-gitreceive does:
 
 | Key                  | Required | Description                                    | Default                 | Example                 |
 |----------------------|----------|------------------------------------------------|-------------------------|-------------------------|
+| `AWS_ACCESS_KEY_ID`   | Required for local | `AWS_ACCESS_KEY_ID` for the access to ECS / ECR |                         | `AKIAawsaccesskey`           |
+| `AWS_SECRET_ACCESS_KEY`   | Required for local | `AWS_SECRET_ACCESS_KEY` for the access to ECS / ECR |                         | `awssecretaccesskey`           |
+| `AWS_REGION`   | Required for local | `AWS_REGION` where Paus cluster runs |                         | `ap-northeast-1`           |
 | `PAUS_BASE_DOMAIN`   | Required | Base domain for application URL                |                         | `pausapp.com`           |
 | `PAUS_DOCKER_HOST` |          | Endpoint of Docker daemon                       | `tcp://127.0.0.1:2375` | `tcp://127.0.0.1:2377` (Docker Swarm) |
 | `PAUS_ETCD_ENDPOINT` |          | Endpoint of etcd cluster                       | `http://127.0.0.1:2379` | `http://127.0.0.1:2379` |

--- a/docker-compose-coreos.yml
+++ b/docker-compose-coreos.yml
@@ -8,6 +8,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION}
       - PAUS_BASE_DOMAIN=pausapp.com
       - PAUS_DOCKER_HOST=tcp://172.17.8.101:2375
       - PAUS_ETCD_ENDPOINT=http://172.17.8.101:2379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_REGION=${AWS_REGION}
       - PAUS_BASE_DOMAIN=pausapp.com
       - PAUS_DOCKER_HOST=unix:///var/run/docker.sock
       - PAUS_ETCD_ENDPOINT=http://etcd:2379

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,10 +30,6 @@ if [ -n "$PAUS_MAX_APP_DEPLOY" ]; then
   echo "MaxAppDeploy=$PAUS_MAX_APP_DEPLOY" >> /paus/config
 fi
 
-if [ -n "$PAUS_REGISTRY_DOMAIN" ]; then
-  echo "RegistryDomain=$PAUS_REGISTRY_DOMAIN" >> /paus/config
-fi
-
 if [ -n "$PAUS_REPOSITORY_DIR" ]; then
   echo "RepositoryDir=$PAUS_REPOSITORY_DIR" >> /paus/config
   chown -R git:git $PAUS_REPOSITORY_DIR

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,10 @@ if [ -n "$PAUS_MAX_APP_DEPLOY" ]; then
   echo "MaxAppDeploy=$PAUS_MAX_APP_DEPLOY" >> /paus/config
 fi
 
+if [ -n "$PAUS_REGISTRY_DOMAIN" ]; then
+  echo "RegistryDomain=$PAUS_REGISTRY_DOMAIN" >> /paus/config
+fi
+
 if [ -n "$PAUS_REPOSITORY_DIR" ]; then
   echo "RepositoryDir=$PAUS_REPOSITORY_DIR" >> /paus/config
   chown -R git:git $PAUS_REPOSITORY_DIR

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,33 +9,46 @@ if [ ! -d /paus ]; then
   mkdir -p /paus
 fi
 
-touch /paus/config
+touch /etc/profile.d/envs.sh
+
+if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+  echo "export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> /etc/profile.d/envs.sh
+fi
+
+if [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo "export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> /etc/profile.d/envs.sh
+fi
+
+if [ -n "$AWS_REGION" ]; then
+  echo "export AWS_REGION=$AWS_REGION" >> /etc/profile.d/envs.sh
+fi
 
 if [ -n "$PAUS_BASE_DOMAIN" ]; then
-  echo "BaseDomain=$PAUS_BASE_DOMAIN" >> /paus/config
+  echo "export PAUS_BASE_DOMAIN=$PAUS_BASE_DOMAIN" >> /etc/profile.d/envs.sh
 else
   echo "required key PAUS_BASE_DOMAIN missing value"
   exit 1
 fi
 
 if [ -n "$PAUS_DOCKER_HOST" ]; then
-  echo "DockerHost=$PAUS_DOCKER_HOST" >> /paus/config
+  echo "export PAUS_DOCKER_HOST=$PAUS_DOCKER_HOST" >> /etc/profile.d/envs.sh
 fi
 
 if [ -n "$PAUS_ETCD_ENDPOINT" ]; then
-  echo "EtcdEndpoint=$PAUS_ETCD_ENDPOINT" >> /paus/config
+  echo "export PAUS_ETCD_ENDPOINT=$PAUS_ETCD_ENDPOINT" >> /etc/profile.d/envs.sh
 fi
 
 if [ -n "$PAUS_MAX_APP_DEPLOY" ]; then
-  echo "MaxAppDeploy=$PAUS_MAX_APP_DEPLOY" >> /paus/config
+  echo "export PAUS_MAX_APP_DEPLOY=$PAUS_MAX_APP_DEPLOY" >> /etc/profile.d/envs.sh
 fi
 
 if [ -n "$PAUS_REPOSITORY_DIR" ]; then
-  echo "RepositoryDir=$PAUS_REPOSITORY_DIR" >> /paus/config
+  echo "export PAUS_REPOSITORY_DIR=$PAUS_REPOSITORY_DIR" >> /etc/profile.d/envs.sh
   chown -R git:git $PAUS_REPOSITORY_DIR
 fi
 
 if [ -n "$PAUS_URI_SCHEME" ]; then
+  echo "export PAUS_URI_SCHEME=$PAUS_URI_SCHEME" >> /etc/profile.d/envs.sh
   echo "URIScheme=$PAUS_URI_SCHEME" >> /paus/config
 fi
 

--- a/files/receiver-wrapper.sh
+++ b/files/receiver-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /etc/profile
+
+/usr/local/bin/receiver $@

--- a/receiver/config/config.go
+++ b/receiver/config/config.go
@@ -22,18 +22,20 @@ var (
 		"DockerHost",
 		"EtcdEndpoint",
 		"MaxAppDeploy",
+		"RegistryDomain",
 		"RepositoryDir",
 		"URIScheme",
 	}
 )
 
 type Config struct {
-	BaseDomain    string `envconfig:"base_domain"`
-	DockerHost    string `envconfig:"docker_host"    default:"tcp://localhost:2375"`
-	EtcdEndpoint  string `envconfig:"etcd_endpoint"  default:"http://localhost:2379"`
-	MaxAppDeploy  int64  `envconfig:"max_app_deploy" default:"10"`
-	RepositoryDir string `envconfig:"repository_dir" default:"/repos"`
-	URIScheme     string `envconfig:"uri_scheme"     default:"http"`
+	BaseDomain     string `envconfig:"base_domain"`
+	DockerHost     string `envconfig:"docker_host"    default:"tcp://localhost:2375"`
+	EtcdEndpoint   string `envconfig:"etcd_endpoint"  default:"http://localhost:2379"`
+	MaxAppDeploy   int64  `envconfig:"max_app_deploy" default:"10"`
+	RegistryDomain string `envconfig:"registry_domain" default:""`
+	RepositoryDir  string `envconfig:"repository_dir" default:"/repos"`
+	URIScheme      string `envconfig:"uri_scheme"     default:"http"`
 }
 
 func loadConfigFromFile(filePath string) (map[string]string, error) {

--- a/receiver/config/config.go
+++ b/receiver/config/config.go
@@ -22,20 +22,19 @@ var (
 		"DockerHost",
 		"EtcdEndpoint",
 		"MaxAppDeploy",
-		"RegistryDomain",
 		"RepositoryDir",
 		"URIScheme",
 	}
 )
 
 type Config struct {
-	BaseDomain     string `envconfig:"base_domain"`
-	DockerHost     string `envconfig:"docker_host"    default:"tcp://localhost:2375"`
-	EtcdEndpoint   string `envconfig:"etcd_endpoint"  default:"http://localhost:2379"`
-	MaxAppDeploy   int64  `envconfig:"max_app_deploy" default:"10"`
-	RegistryDomain string `envconfig:"registry_domain" default:""`
-	RepositoryDir  string `envconfig:"repository_dir" default:"/repos"`
-	URIScheme      string `envconfig:"uri_scheme"     default:"http"`
+	AWSRegion     string
+	BaseDomain    string `envconfig:"base_domain"`
+	DockerHost    string `envconfig:"docker_host"    default:"tcp://localhost:2375"`
+	EtcdEndpoint  string `envconfig:"etcd_endpoint"  default:"http://localhost:2379"`
+	MaxAppDeploy  int64  `envconfig:"max_app_deploy" default:"10"`
+	RepositoryDir string `envconfig:"repository_dir" default:"/repos"`
+	URIScheme     string `envconfig:"uri_scheme"     default:"http"`
 }
 
 func loadConfigFromFile(filePath string) (map[string]string, error) {
@@ -98,6 +97,8 @@ func LoadConfig() (*Config, error) {
 			reflect.ValueOf(&config).Elem().FieldByName(configName).SetString(configFromFile[configName])
 		}
 	}
+
+	config.AWSRegion = os.Getenv("AWS_REGION")
 
 	return &config, nil
 }

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -11,12 +11,12 @@ import (
 	"github.com/dtan4/paus-gitreceive/receiver/vulcand"
 )
 
-func deploy(application *model.Application, compose *model.Compose) (string, error) {
+func deploy(application *model.Application, compose *model.Compose, dockerHost, registryDomain string, deployment *model.Deployment) (string, error) {
 	var err error
 
 	fmt.Println("=====> Building ...")
 
-	if err = compose.Build(); err != nil {
+	if err = compose.Build(dockerHost, registryDomain, deployment); err != nil {
 		return "", err
 	}
 

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -16,7 +16,15 @@ func deploy(application *model.Application, compose *model.Compose, deployment *
 
 	fmt.Println("=====> Building ...")
 
-	if _, err = compose.Build(deployment); err != nil {
+	images, err := compose.Build(deployment)
+
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Println("=====> Pushing ...")
+
+	if err = compose.Push(images); err != nil {
 		return "", err
 	}
 

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -16,7 +16,7 @@ func deploy(application *model.Application, compose *model.Compose, deployment *
 
 	fmt.Println("=====> Building ...")
 
-	if err = compose.Build(deployment); err != nil {
+	if _, err = compose.Build(deployment); err != nil {
 		return "", err
 	}
 

--- a/receiver/deploy.go
+++ b/receiver/deploy.go
@@ -11,12 +11,12 @@ import (
 	"github.com/dtan4/paus-gitreceive/receiver/vulcand"
 )
 
-func deploy(application *model.Application, compose *model.Compose, dockerHost, registryDomain string, deployment *model.Deployment) (string, error) {
+func deploy(application *model.Application, compose *model.Compose, deployment *model.Deployment) (string, error) {
 	var err error
 
 	fmt.Println("=====> Building ...")
 
-	if err = compose.Build(dockerHost, registryDomain, deployment); err != nil {
+	if err = compose.Build(deployment); err != nil {
 		return "", err
 	}
 
@@ -112,7 +112,8 @@ func rotateDeployments(etcd *store.Etcd, application *model.Application, maxAppD
 
 	fmt.Println("=====> Stop " + oldestDeployment.Revision + " ...")
 
-	compose, err := model.NewCompose(dockerHost, oldestDeployment.ComposeFilePath, oldestDeployment.ProjectName)
+	// TODO: set registryDomain
+	compose, err := model.NewCompose(dockerHost, oldestDeployment.ComposeFilePath, oldestDeployment.ProjectName, "")
 
 	if err != nil {
 		return err

--- a/receiver/glide.lock
+++ b/receiver/glide.lock
@@ -1,6 +1,34 @@
-hash: e2456ed949d2385f72ac010fc14d83e04d4502ad6240c80279bf26d131d6b746
-updated: 2016-10-20T14:21:42.393162371+09:00
+hash: ad8d33899fbfc02036b13781ca5cdca5d4e0f0c27d25c14c6da88193bfa67ad0
+updated: 2016-10-20T20:33:30.012239094+09:00
 imports:
+- name: github.com/aws/aws-sdk-go
+  version: 1a651d9028d1203f4a0ba9fee91b207536cd4ca2
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - private/endpoints
+  - private/protocol
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/xml/xmlutil
+  - service/ecr
+  - service/sts
 - name: github.com/coreos/etcd
   version: c33ea20fefe0f435374258ca201cd5fc5edd0ab3
   subpackages:
@@ -59,8 +87,12 @@ imports:
   version: 3f9db97f856818214da2e1057f8ad84803971cff
 - name: github.com/fsouza/go-dockerclient
   version: a53ba79627e888ef775bdcf15813f07d7a232867
+- name: github.com/go-ini/ini
+  version: cf53f9204df4fbdd7ec4164b57fa6184ba168292
 - name: github.com/hashicorp/go-cleanhttp
   version: ad28ea4487f05916463e2423a55166280e8254b5
+- name: github.com/jmespath/go-jmespath
+  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/kelseyhightower/envconfig
   version: 3ef4de09ad56571e5d8b3cfdcd31941c0c5e3db9
 - name: github.com/opencontainers/runc

--- a/receiver/glide.yaml
+++ b/receiver/glide.yaml
@@ -14,3 +14,10 @@ import:
   - project
   - config
   - lookup
+- package: github.com/aws/aws-sdk-go
+  version: ~1.4.19
+  subpackages:
+  - aws
+  - aws/session
+  - service/ecr
+  - service/sts

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -95,7 +95,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	compose, err := model.NewCompose(config.DockerHost, composeFilePath, deployment.ProjectName)
+	compose, err := model.NewCompose(config.DockerHost, composeFilePath, deployment.ProjectName, config.RegistryDomain)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
@@ -107,7 +107,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	webContainerID, err := deploy(application, compose, config.DockerHost, config.RegistryDomain, deployment)
+	webContainerID, err := deploy(application, compose, deployment)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -107,7 +107,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	webContainerID, err := deploy(application, compose)
+	webContainerID, err := deploy(application, compose, config.DockerHost, config.RegistryDomain, deployment)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -95,7 +95,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	compose, err := model.NewCompose(config.DockerHost, composeFilePath, deployment.ProjectName, config.RegistryDomain)
+	compose, err := model.NewCompose(config.DockerHost, composeFilePath, deployment.ProjectName, config.AWSRegion)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)

--- a/receiver/model/compose.go
+++ b/receiver/model/compose.go
@@ -46,7 +46,7 @@ type ComposeConfig struct {
 	Networks map[string]*config.NetworkConfig `yaml:"networks,omitempty"`
 }
 
-func NewCompose(dockerHost, composeFilePath, projectName, registryDomain string) (*Compose, error) {
+func NewCompose(dockerHost, composeFilePath, projectName, awsRegion string) (*Compose, error) {
 	ctx := project.Context{
 		ComposeFiles: []string{composeFilePath},
 		ProjectName:  projectName,
@@ -64,6 +64,13 @@ func NewCompose(dockerHost, composeFilePath, projectName, registryDomain string)
 	if err := prj.Parse(); err != nil {
 		return nil, errors.Wrap(err, "Failed to parse docker-compose.yml.")
 	}
+
+	accountID, err := service.GetAWSAccountID()
+	if err != nil {
+		return nil, err
+	}
+
+	registryDomain := service.GetRegistryDomain(accountID, awsRegion)
 
 	return &Compose{
 		ComposeFilePath: composeFilePath,

--- a/receiver/model/compose.go
+++ b/receiver/model/compose.go
@@ -136,6 +136,28 @@ func (c *Compose) Build(deployment *Deployment) ([]*Image, error) {
 	return images, nil
 }
 
+func (c *Compose) Push(images []*Image) error {
+	var (
+		opts docker.PushImageOptions
+	)
+
+	client, _ := docker.NewClient(c.dockerHost)
+
+	for _, image := range images {
+		opts = docker.PushImageOptions{
+			Registry: image.Registry,
+			Name:     image.Name,
+			Tag:      image.Tag,
+		}
+
+		if err := client.PushImage(opts, docker.AuthConfiguration{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (c *Compose) GetContainerID(service string) (string, error) {
 	cmd := exec.Command("docker-compose", "-f", c.ComposeFilePath, "-p", c.ProjectName, "ps", "-q", service)
 	cmd.Env = append(os.Environ(), "DOCKER_HOST="+c.dockerHost)

--- a/receiver/model/compose.go
+++ b/receiver/model/compose.go
@@ -47,6 +47,8 @@ type ComposeConfig struct {
 }
 
 func NewCompose(dockerHost, composeFilePath, projectName, awsRegion string) (*Compose, error) {
+	var registryDomain string
+
 	ctx := project.Context{
 		ComposeFiles: []string{composeFilePath},
 		ProjectName:  projectName,
@@ -65,12 +67,14 @@ func NewCompose(dockerHost, composeFilePath, projectName, awsRegion string) (*Co
 		return nil, errors.Wrap(err, "Failed to parse docker-compose.yml.")
 	}
 
-	accountID, err := service.GetAWSAccountID()
-	if err != nil {
-		return nil, err
-	}
+	if awsRegion != "" {
+		accountID, err := service.GetAWSAccountID()
+		if err != nil {
+			return nil, err
+		}
 
-	registryDomain := service.GetRegistryDomain(accountID, awsRegion)
+		registryDomain = service.GetRegistryDomain(accountID, awsRegion)
+	}
 
 	return &Compose{
 		ComposeFilePath: composeFilePath,

--- a/receiver/model/compose.go
+++ b/receiver/model/compose.go
@@ -73,6 +73,10 @@ func NewCompose(dockerHost, composeFilePath, projectName, registryDomain string)
 	}, nil
 }
 
+func (c *Compose) ImageName(username, appName, serviceName, revision string) string {
+	return fmt.Sprintf("%s/%s-%s-%s:%s", c.RegistryDomain, username, appName, serviceName, revision)
+}
+
 func (c *Compose) Build(deployment *Deployment) error {
 	var (
 		buildArgs []docker.BuildArg
@@ -106,7 +110,7 @@ func (c *Compose) Build(deployment *Deployment) error {
 			BuildArgs:      buildArgs,
 			ContextDir:     svc.Build.Context,
 			Dockerfile:     svc.Build.Dockerfile,
-			Name:           fmt.Sprintf("%s/%s/%s-%s:%s", c.RegistryDomain, deployment.App.Username, deployment.App.AppName, name, deployment.Revision),
+			Name:           c.ImageName(deployment.App.Username, deployment.App.AppName, name, deployment.Revision),
 			OutputStream:   outputBuf,
 			Pull:           true,
 			SuppressOutput: false,

--- a/receiver/model/compose_test.go
+++ b/receiver/model/compose_test.go
@@ -56,29 +56,6 @@ func setup() {
 	v2ComposeNoBuildEnv, _ = NewCompose(dockerHost, v2FilePathNoBuildEnv, projectName, registryDomain)
 }
 
-func TestImageName(t *testing.T) {
-	var actual string
-
-	setup()
-
-	username := "dtan4"
-	appName := "paus"
-	serviceName := "web"
-	revision := "1234abcd"
-
-	expected := "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/dtan4-paus-web:1234abcd"
-
-	actual = v1Compose.ImageName(username, appName, serviceName, revision)
-	if actual != expected {
-		t.Fatalf("Image name from v1 is wrong. expected: %s, actual: %s", expected, actual)
-	}
-
-	actual = v2Compose.ImageName(username, appName, serviceName, revision)
-	if actual != expected {
-		t.Fatalf("Image name from compose v2 is wrong. expected: %s, actual: %s", expected, actual)
-	}
-}
-
 func TestInjectBuildArgs(t *testing.T) {
 	var (
 		buildArgs map[string]string

--- a/receiver/model/compose_test.go
+++ b/receiver/model/compose_test.go
@@ -56,6 +56,29 @@ func setup() {
 	v2ComposeNoBuildEnv, _ = NewCompose(dockerHost, v2FilePathNoBuildEnv, projectName, registryDomain)
 }
 
+func TestImageName(t *testing.T) {
+	var actual string
+
+	setup()
+
+	username := "dtan4"
+	appName := "paus"
+	serviceName := "web"
+	revision := "1234abcd"
+
+	expected := "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/dtan4-paus-web:1234abcd"
+
+	actual = v1Compose.ImageName(username, appName, serviceName, revision)
+	if actual != expected {
+		t.Fatalf("Image name from v1 is wrong. expected: %s, actual: %s", expected, actual)
+	}
+
+	actual = v2Compose.ImageName(username, appName, serviceName, revision)
+	if actual != expected {
+		t.Fatalf("Image name from compose v2 is wrong. expected: %s, actual: %s", expected, actual)
+	}
+}
+
 func TestInjectBuildArgs(t *testing.T) {
 	var (
 		buildArgs map[string]string

--- a/receiver/model/compose_test.go
+++ b/receiver/model/compose_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	dockerHost  = "unix:///var/run/docker.sock"
-	projectName = "paustest"
+	dockerHost     = "unix:///var/run/docker.sock"
+	projectName    = "paustest"
+	registryDomain = "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com"
 )
 
 var (
@@ -49,10 +50,10 @@ func setup() {
 	v2FilePathBuildArg = fixturePath("docker-compose-v2-buildarg.yml")
 	v2FilePathNoBuildEnv = fixturePath("docker-compose-v2-nobuildenv.yml")
 
-	v1Compose, _ = NewCompose(dockerHost, v1FilePath, projectName)
-	v2Compose, _ = NewCompose(dockerHost, v2FilePath, projectName)
-	v2ComposeBuildArg, _ = NewCompose(dockerHost, v2FilePathBuildArg, projectName)
-	v2ComposeNoBuildEnv, _ = NewCompose(dockerHost, v2FilePathNoBuildEnv, projectName)
+	v1Compose, _ = NewCompose(dockerHost, v1FilePath, projectName, registryDomain)
+	v2Compose, _ = NewCompose(dockerHost, v2FilePath, projectName, registryDomain)
+	v2ComposeBuildArg, _ = NewCompose(dockerHost, v2FilePathBuildArg, projectName, registryDomain)
+	v2ComposeNoBuildEnv, _ = NewCompose(dockerHost, v2FilePathNoBuildEnv, projectName, registryDomain)
 }
 
 func TestInjectBuildArgs(t *testing.T) {

--- a/receiver/model/compose_test.go
+++ b/receiver/model/compose_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	dockerHost     = "unix:///var/run/docker.sock"
-	projectName    = "paustest"
-	registryDomain = "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com"
+	dockerHost  = "unix:///var/run/docker.sock"
+	projectName = "paustest"
+	awsRegion   = ""
 )
 
 var (
@@ -50,10 +50,10 @@ func setup() {
 	v2FilePathBuildArg = fixturePath("docker-compose-v2-buildarg.yml")
 	v2FilePathNoBuildEnv = fixturePath("docker-compose-v2-nobuildenv.yml")
 
-	v1Compose, _ = NewCompose(dockerHost, v1FilePath, projectName, registryDomain)
-	v2Compose, _ = NewCompose(dockerHost, v2FilePath, projectName, registryDomain)
-	v2ComposeBuildArg, _ = NewCompose(dockerHost, v2FilePathBuildArg, projectName, registryDomain)
-	v2ComposeNoBuildEnv, _ = NewCompose(dockerHost, v2FilePathNoBuildEnv, projectName, registryDomain)
+	v1Compose, _ = NewCompose(dockerHost, v1FilePath, projectName, awsRegion)
+	v2Compose, _ = NewCompose(dockerHost, v2FilePath, projectName, awsRegion)
+	v2ComposeBuildArg, _ = NewCompose(dockerHost, v2FilePathBuildArg, projectName, awsRegion)
+	v2ComposeNoBuildEnv, _ = NewCompose(dockerHost, v2FilePathNoBuildEnv, projectName, awsRegion)
 }
 
 func TestInjectBuildArgs(t *testing.T) {

--- a/receiver/model/image.go
+++ b/receiver/model/image.go
@@ -1,0 +1,19 @@
+package model
+
+type Image struct {
+	Name     string
+	Registry string
+	Tag      string
+}
+
+func NewImage(name, registry, tag string) *Image {
+	return &Image{
+		Name:     name,
+		Registry: registry,
+		Tag:      tag,
+	}
+}
+
+func (i *Image) String() string {
+	return i.Registry + "/" + i.Name + ":" + i.Tag
+}

--- a/receiver/model/image.go
+++ b/receiver/model/image.go
@@ -1,17 +1,60 @@
 package model
 
+import (
+	"fmt"
+	"strings"
+)
+
+const ecrDomainSuffix = "amazonaws.com"
+
 type Image struct {
-	Name     string
 	Registry string
+	Name     string
 	Tag      string
 }
 
-func NewImage(name, registry, tag string) *Image {
+func NewImage(registry, name, tag string) *Image {
 	return &Image{
-		Name:     name,
 		Registry: registry,
+		Name:     name,
 		Tag:      tag,
 	}
+}
+
+func ImageFromString(s string) (*Image, error) {
+	var registry, name, tag string
+
+	ss := strings.Split(s, ":")
+
+	if len(ss) >= 3 {
+		return nil, fmt.Errorf("Invalid image string. %s", s)
+	}
+
+	if len(ss) == 2 {
+		tag = ss[1]
+	}
+
+	ss2 := strings.Split(ss[0], "/")
+
+	if len(ss2) == 1 {
+		name = ss2[0]
+	} else if len(ss2) == 2 {
+		if strings.HasSuffix(ss2[0], ecrDomainSuffix) {
+			registry = ss2[0]
+			name = ss2[1]
+		} else {
+			name = ss[0]
+		}
+	} else {
+		registry = ss2[0]
+		name = strings.SplitN(ss[0], "/", 2)[1]
+	}
+
+	return &Image{
+		Registry: registry,
+		Name:     name,
+		Tag:      tag,
+	}, nil
 }
 
 func (i *Image) String() string {

--- a/receiver/model/image_test.go
+++ b/receiver/model/image_test.go
@@ -4,14 +4,91 @@ import (
 	"testing"
 )
 
+func TestImageFromString(t *testing.T) {
+	var (
+		image *Image
+		s     string
+		err   error
+	)
+
+	var testdata = []struct {
+		s        string
+		registry string
+		name     string
+		tag      string
+	}{
+		{
+			s:        "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/paus",
+			registry: "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com",
+			name:     "paus",
+			tag:      "",
+		},
+		{
+			s:        "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/paus:1.0.0",
+			registry: "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com",
+			name:     "paus",
+			tag:      "1.0.0",
+		},
+		{
+			s:        "dtan4/paus:1.0.0",
+			registry: "",
+			name:     "dtan4/paus",
+			tag:      "1.0.0",
+		},
+		{
+			s:        "quay.io/dtan4/paus:1.0.0",
+			registry: "quay.io",
+			name:     "dtan4/paus",
+			tag:      "1.0.0",
+		},
+		{
+			s:        "paus",
+			registry: "",
+			name:     "paus",
+			tag:      "",
+		},
+		{
+			s:        "paus:1.0.0",
+			registry: "",
+			name:     "paus",
+			tag:      "1.0.0",
+		},
+	}
+
+	for _, td := range testdata {
+		image, err = ImageFromString(td.s)
+		if err != nil {
+			t.Fatalf("Error should not be raised. string: %#v, error: %#v", td.s, err)
+		}
+
+		if image.Registry != td.registry {
+			t.Fatalf("Registry should be '"+td.registry+"'. actual: %#v", image.Registry)
+		}
+
+		if image.Name != td.name {
+			t.Fatalf("Name should be '"+td.name+"'. actual: %#v", image.Name)
+		}
+
+		if image.Tag != td.tag {
+			t.Fatalf("Tag should be '"+td.tag+"'. actual: %#v", image.Tag)
+		}
+	}
+
+	s = "foobar:1.0.0:hoge"
+	_, err = ImageFromString(s)
+	if err == nil {
+		t.Fatalf("Error should not raised. string: %#v", s)
+	}
+}
+
 func TestString(t *testing.T) {
-	name := "paus"
 	registry := "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com"
+	name := "paus"
 	tag := "1.0.0"
 
 	image := &Image{
-		Name:     name,
 		Registry: registry,
+		Name:     name,
 		Tag:      tag,
 	}
 

--- a/receiver/model/image_test.go
+++ b/receiver/model/image_test.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	name := "paus"
+	registry := "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com"
+	tag := "1.0.0"
+
+	image := &Image{
+		Name:     name,
+		Registry: registry,
+		Tag:      tag,
+	}
+
+	expected := "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/paus:1.0.0"
+	actual := image.String()
+
+	if actual != expected {
+		t.Fatalf("Wrong image fullname. expected: %#v, actual: %#v", expected, actual)
+	}
+}

--- a/receiver/service/ecr.go
+++ b/receiver/service/ecr.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 )
 
+// CreateRepository creates new Repository
 func CreateRepository(registryID, repository string) error {
 	svc := ecr.New(session.New(), &aws.Config{})
 
@@ -20,6 +21,7 @@ func CreateRepository(registryID, repository string) error {
 	return nil
 }
 
+// GetECRToken returns ECR authrization token
 func GetECRToken(registryID string) (string, error) {
 	svc := ecr.New(session.New(), &aws.Config{})
 
@@ -35,6 +37,12 @@ func GetECRToken(registryID string) (string, error) {
 	return *resp.AuthorizationData[0].AuthorizationToken, nil
 }
 
+// GetRegistryDomain returns fully-qualified ECR registry domain
+func GetRegistryDomain(accountID, region string) string {
+	return accountID + ".dkr.ecr." + region + ".amazonaws.com"
+}
+
+// RepositoryExists returns whether the specified repository exists or not
 func RepositoryExists(registryID, repository string) (bool, error) {
 	svc := ecr.New(session.New(), &aws.Config{})
 

--- a/receiver/service/ecr.go
+++ b/receiver/service/ecr.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+)
+
+func GetECRToken(registryID string) (string, error) {
+	svc := ecr.New(session.New(), &aws.Config{})
+
+	resp, err := svc.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{
+		RegistryIds: []*string{
+			aws.String(registryID),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return *resp.AuthorizationData[0].AuthorizationToken, nil
+}

--- a/receiver/service/ecr.go
+++ b/receiver/service/ecr.go
@@ -6,6 +6,20 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 )
 
+func CreateRepository(registryID, repository string) error {
+	svc := ecr.New(session.New(), &aws.Config{})
+
+	_, err := svc.CreateRepository(&ecr.CreateRepositoryInput{
+		RepositoryName: aws.String(repository),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func GetECRToken(registryID string) (string, error) {
 	svc := ecr.New(session.New(), &aws.Config{})
 
@@ -19,4 +33,24 @@ func GetECRToken(registryID string) (string, error) {
 	}
 
 	return *resp.AuthorizationData[0].AuthorizationToken, nil
+}
+
+func RepositoryExists(registryID, repository string) (bool, error) {
+	svc := ecr.New(session.New(), &aws.Config{})
+
+	resp, err := svc.DescribeRepositories(&ecr.DescribeRepositoriesInput{
+		RepositoryNames: []*string{
+			aws.String(repository),
+		},
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(resp.Repositories) == 0 {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/receiver/service/sts.go
+++ b/receiver/service/sts.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+func GetAWSAccountID() (string, error) {
+	svc := sts.New(session.New(), &aws.Config{})
+
+	resp, err := svc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+
+	return *resp.Account, nil
+}


### PR DESCRIPTION
from https://github.com/dtan4/paus/issues/19
## WHY

After migrating to ECS, we have to prepare some Docker Registry. Because we cannot use `docker-compose build && docker-compose up` on ECR.

ECR is a good solution to have own private registry. 
## WHAT

After building Docker image, push the image to ECR. 
